### PR TITLE
Set up automatic Storybook build & deployment

### DIFF
--- a/.github/workflows/build-deploy-storybook.yml
+++ b/.github/workflows/build-deploy-storybook.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies 🧱
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '14.4.0'
           cache: 'npm'
 
       - name: Build static Storybook 🛠


### PR DESCRIPTION
This GitHub Actions workflow should automatically build the static version of Storybook and publish it to the gh-pages branch on every push to main. Once this is merged (which should trigger a run), I'll enable GitHub Pages on the repo.