### PR TITLE
Updating npm badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Explorer 1: JPL's Design System
 
-[![Release info](https://img.shields.io/badge/version-1.0.0--beta.1-yellowgreen)](https://github.com/nasa-jpl/explorer-1/releases)
-[![View on npm](https://img.shields.io/badge/npm-@nasa--jpl%2Fexplorer--1-informational)](https://npmjs.com/package/@nasa-jpl/explorer-1)
+[![npm](https://img.shields.io/npm/v/@nasa-jpl/explorer-1)](https://npmjs.com/package/@nasa-jpl/explorer-1)
 [![View on GitHub](https://img.shields.io/badge/github-nasa--jpl%2Fexplorer--1-informational)](https://github.com/nasa-jpl/explorer-1)
 
 This package aims to include all of the frontend assets (JS and SCSS) necessary to create components using the HTML markup examples in the [Explorer 1 Storybook](https://nasa-jpl.github.io/explorer-1/).


### PR DESCRIPTION
A short and sweet update that replaces two badges with one much more functional one!

To Test:
- View the README.md as rendered markdown
- It should show an accurate version number and link to the package on npmjs.com