### PR TITLE
Storybook: Add `BasePlaceholder` component

### DIFF
--- a/storybook/stories/components/BasePlaceholder/BasePlaceholder.js
+++ b/storybook/stories/components/BasePlaceholder/BasePlaceholder.js
@@ -1,0 +1,32 @@
+export const BasePlaceholderTemplate = () => {
+  return `
+  <div class="BasePlaceholder">
+    <div class="border-bottom grid w-full grid-cols-12 mb-10">
+      <div class="col-span-9 pr-5">
+        <div
+          class="bg-gray-light-mid animate-loading w-64 h-4 rounded-lg"
+        ></div>
+        <div
+          class="bg-gray-light-mid animate-loading w-56 h-4 mt-5 rounded-lg"
+        ></div>
+        <div
+          class="bg-gray-light-mid animate-loading pr-14 w-full h-4 mt-6 rounded-lg"
+        ></div>
+        <div
+          class="bg-gray-light-mid animate-loading pr-14 w-5/6 h-4 mt-3 rounded-lg"
+        ></div>
+        <div
+          class="bg-gray-light-mid animate-loading pr-14 w-1/2 h-4 mt-3 rounded-lg"
+        ></div>
+        <div
+          class="bg-gray-light-mid animate-loading pr-14 w-30 h-4 mt-4 rounded-lg"
+        ></div>
+      </div>
+      <div class="flex justify-end col-span-3">
+        <div class="animate-loading h-38 w-38 rounded-none"></div>
+      </div>
+    </div>
+    <hr class="text-gray-light-mid mb-10" />
+  </div>
+  `
+}

--- a/storybook/stories/components/BasePlaceholder/BasePlaceholder.stories.js
+++ b/storybook/stories/components/BasePlaceholder/BasePlaceholder.stories.js
@@ -1,0 +1,16 @@
+import { BasePlaceholderTemplate } from './BasePlaceholder'
+
+export default {
+  title: 'Components/Base/BasePlaceholder',
+  parameters: {
+    viewMode: 'docs',
+    docs: {
+      description: {
+        component:
+          'An animated loading component frequently used as a placeholder for `SearchResultCard`',
+      },
+    },
+  },
+}
+
+export const Default = BasePlaceholderTemplate.bind()


### PR DESCRIPTION
Adding `BasePlaceholder` to our [components list](https://github.com/nasa-jpl/explorer-1/issues/10). 

To test :
1. Pull this branch
2. `npm run storybook`

View it under `Components > Base > BasePlaceholder`
http://localhost:6006/?path=/docs/components-base-baseplaceholder--default