### PR TITLE
Pull Requests: updates links in the the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,9 +7,9 @@
 - [ ] List the environments / browsers in which you tested your changes.
 - [ ] Tests, linting, or other required checks are passing.
 - [ ] PR has an informative and human-readable title
-  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
+  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
   - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
-- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a general category label, or skip-changelog.
+- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
   - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
   - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.
 


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [x] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a general category label, or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Updates to the pull request template:

- fixes the link to releases
- adds a link to our Release Drafter config, specifically to the category/label configurations. I often want to check the config, at least while getting used to Release Drafter, and thought it would be handy to have the link the PR.

## Instructions to test

You can view the github rendered markdown, but the relative link to releases won't work until this PR is merged.
