### PR TITLE
Storybook: Add `BlockTeaser` component

### DIFF
--- a/storybook/stories/components/BlockTeaser/BlockTeaser.js
+++ b/storybook/stories/components/BlockTeaser/BlockTeaser.js
@@ -18,6 +18,7 @@ export const BlockTeaserTemplate = ({
       heading +
       `</${headingSize}>`
   }
+  image = image && fullWidthImage ? image.full : image ? image.half : ''
 
   return `
   <div class="BlockTeaser bg-gray-light lg:grid lg:grid-cols-10 relative" style="${

--- a/storybook/stories/components/BlockTeaser/BlockTeaser.stories.js
+++ b/storybook/stories/components/BlockTeaser/BlockTeaser.stories.js
@@ -66,15 +66,11 @@ export const BlockTeaserData = {
 }
 
 export const Default = BlockTeaserTemplate.bind({})
-Default.args = {
-  ...BlockTeaserData,
-  image: BlockTeaserData.image.half,
-}
+Default.args = BlockTeaserData
 
 export const FullWidth = BlockTeaserTemplate.bind({})
 FullWidth.args = {
   ...BlockTeaserData,
-  image: BlockTeaserData.image.full,
   fullWidthImage: true,
 }
 


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Adding `BlockTeaser` to our [components list](https://github.com/nasa-jpl/explorer-1/issues/10). 

## Instructions to test

1. Pull this branch
2. `npm run storybook`

View it under `Components > Blocks > BlockTeaser`
http://localhost:6006/?path=/docs/components-blocks-blockteaser--default

WWW Storybook equivalent: https://designlab.jpl.nasa.gov/storybook/?path=/docs/components-blocks-blockteaser--default

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [ ] Firefox ESR
- [x] Firefox
- [x] Safari
- [ ] Edge
