### PR TITLE
Storybook: Add `HeroFocalPoint` component

### DIFF
--- a/storybook/stories/components/HeroFocalPoint/HeroFocalPoint.js
+++ b/storybook/stories/components/HeroFocalPoint/HeroFocalPoint.js
@@ -1,10 +1,4 @@
-export const HeroFocalPointTemplate = ({
-  image,
-  hasOverlay,
-  eyebrow,
-  title,
-  summary,
-}) => {
+export const HeroFocalPointTemplate = ({ image, eyebrow, title, summary }) => {
   return `
   <div class="HeroFocalPoint max-w-screen-3xl relative mx-auto">
     <div class="absolute inset-0 z-10 bg-black">
@@ -25,9 +19,7 @@ export const HeroFocalPointTemplate = ({
       <div class="bg-gradient-to-t lg:bg-gradient-to-l from-transparent-w25 lg:from-transparent-w50 to-transparent-black-50 lg:to-transparent-black-50 absolute inset-0"></div>
       <div class="text-contrast relative w-full text-white">
         <div class="lg:py-0 pb-80 container pt-8 mx-auto">
-          <div class="lg:px-10 2xl:px-0 lg:pt-6 lg:pb-18 px-4 ${
-            hasOverlay ? 'pt-10' : ''
-          }">
+          <div class="lg:px-10 2xl:px-0 lg:pt-6 lg:pb-18 px-4">
             ${
               eyebrow
                 ? `<div class="lg:mb-6 font-secondary mb-4 text-base font-semibold tracking-wider no-underline uppercase">${eyebrow}<span class="sr-only">.</span></div>`

--- a/storybook/stories/components/HeroFocalPoint/HeroFocalPoint.stories.js
+++ b/storybook/stories/components/HeroFocalPoint/HeroFocalPoint.stories.js
@@ -15,16 +15,6 @@ export default {
       type: { name: 'string', required: false },
       description: 'Summary/description of the hero item',
     },
-    hasOverlay: {
-      type: 'boolean',
-      description: '',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: 'false' },
-      },
-    },
   },
   parameters: {
     viewMode: 'canvas',
@@ -38,7 +28,6 @@ Hero.args = {
   title: 'FreeClimber: LEMUR 3',
   summary:
     'Crawl, walk and even climb rock walls, this robot was designed to operate in extreme terrains.',
-  hasOverlay: false,
   image: {
     src: {
       url: 'https://picsum.photos/id/973/1800/1200',


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Adding `HeroFocalPoint` to our [components list](https://github.com/nasa-jpl/explorer-1/issues/10). 

## Instructions to test

1. Pull this branch
2. `npm run storybook`

View it under `Components > Heroes > HeroFocalPoint`:
http://localhost:6006/?path=/story/components-heroes-herofocalpoint--hero

WWW Storybook equivalent: 
https://designlab.jpl.nasa.gov/storybook/?path=/docs/components-heroes-herofocalpoint--hero

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [ ] Firefox ESR
- [x] Firefox
- [x] Safari
- [ ] Edge
