### PR TITLE
Revert usage of sass:math module

### DIFF
--- a/src/scss/_aspect-ratios.scss
+++ b/src/scss/_aspect-ratios.scss
@@ -1,5 +1,4 @@
 // aspect-ratios.scss
-@use 'sass:math';
 
 // Aspect Ratio Containment Mixin
 @mixin aspect-ratio($width, $height) {
@@ -8,7 +7,7 @@
       content: '';
       @apply block w-full;
 
-      padding-bottom: math.div($height, $width) * 100%;
+      padding-bottom: ($height / $width) * 100%;
     }
 
     iframe,


### PR DESCRIPTION
### Checklist

- [ ] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

This PR reverts the fix in https://github.com/nasa-jpl/explorer-1/pull/62 that removed the deprecation warning around the `/`. Merging this may be necessary to release explorer 1 beta 3 for usage in WCP.

## Instructions to test

<!-- Provide instructions on how a reviewer can verify your work. -->

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
