### PR TITLE
Remove unused postcss-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31135,28 +31135,6 @@
         }
       }
     },
-    "postcss-loader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-5.0.0.tgz",
-      "integrity": "sha512-bOvyWP5VHCJbThbv7wrBwCBc3DsVpyCfd+k/wHOL3wTAMMHmSSfNts90EADf8bHa6I810ird1JBEKmBRgJu3cg==",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "^7.0.0",
-        "klona": "^2.0.4",
-        "semver": "^7.3.4"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
     "postcss-logical": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "parcel": "^2.0.0-beta.2",
     "parcel-namer-rewrite": "^2.0.0-rc.2",
     "postcss": "^8.4.5",
-    "postcss-loader": "^5.0.0",
     "postcss-preset-env": "^7.1.0",
     "prettier": "^2.4.1",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Determined that we weren't using postcss-loader. See: https://github.com/nasa-jpl/explorer-1/pull/86#issuecomment-1015566927

## Instructions to test

1. `npm i`
2. Verify that the following work without issue:
   - `npm run build`
   - `npm run dev`
   - `npm run storybook`

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
