### PR TITLE
Docs: Fixing the link to the Explorer 1 readme

### DIFF
--- a/storybook/stories/_docs/gettingstarted_developer.stories.mdx
+++ b/storybook/stories/_docs/gettingstarted_developer.stories.mdx
@@ -14,7 +14,7 @@ To use the Explorer 1 design system, there are three things you will need:
 
 [![npm](https://img.shields.io/npm/v/@nasa-jpl/explorer-1)](https://npmjs.com/package/@nasa-jpl/explorer-1)
 
-This package includes all of the frontend assets (JS and SCSS) necessary to create components using the HTML markup examples in this Storybook. For information on how to install and use the npm package, please refer to the [@nasa-jpl/explorer-1 README](https://github.com/@nasa-jpl/explorer-1).
+This package includes all of the frontend assets (JS and SCSS) necessary to create components using the HTML markup examples in this Storybook. For information on how to install and use the npm package, please refer to the [@nasa-jpl/explorer-1 README](https://github.com/nasa-jpl/explorer-1).
 
 ## Design system foundations
 


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [x] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Fixing a broken link to the repo README from the Getting Started Guide for Developers. Previously the link was pointing to a 404 due to a stray `@`.

## Instructions to test

Test the link to the explorer-1 repo readme in the getting started guide for developers. It should now work! 

