### PR TITLE
Update Tailwind config to not activate dark mode based on user's OS-level setting

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -65,6 +65,7 @@ const fallbackFontStack = [
 ]
 
 module.exports = {
+  darkMode: 'class',
   theme: {
     screens: {
       sm: '640px',


### PR DESCRIPTION
darkMode: 'class',

[Now that dark mode is a first-class feature of many operating systems, it’s becoming more and more common to design a dark version of your website to go along with the default design. it's now supported fully in the tailwind typography library](https://tailwindcss.com/docs/dark-mode)