### PR TITLE
Revert prettier to v2.5.1 to fix Storybook HTML addon

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
             'stylelint-config-standard@22.0.0',
           ]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.0
+    rev: v2.5.1
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-eslint

--- a/package-lock.json
+++ b/package-lock.json
@@ -24440,9 +24440,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
-      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "pretty-error": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "parcel-namer-rewrite": "^2.0.0-rc.2",
     "postcss": "^8.4.12",
     "postcss-preset-env": "^7.4.2",
-    "prettier": "^2.6.0",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "storybook-addon-themes": "^6.1.0",
     "stylelint": "^13.13.1",


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Reverts https://github.com/nasa-jpl/explorer-1/pull/184 to fix the Storybook HTML addon. The HTML tab in the compiled Storybook was missing, and upon running `npm run build-storybook`, I discovered this error:

```
WARN ./node_modules/prettier/standalone.js 68:43-50
WARN Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
```

Which led me to this issue:
https://github.com/prettier/prettier/issues/12493

The fix referred to in [this comment](https://github.com/prettier/prettier/issues/12493#issuecomment-1073944937) is not yet merged, and I confirmed that replacing the files as discussed in that comment thread does fix the issue. Reverting Prettier until the fix is merged and released.

## Instructions to test

1. You can see that the HTML tab is missing on the current live Storybook: https://nasa-jpl.github.io/explorer-1/?path=/story/components-base-basebutton--primary-button
2. In this branch, `npm i` 
3. then `npm run build-storybook`
4. make sure storybook builds without errors
5. Test static storybook locally. I usually do this by running `python3 -m http.server 8005` in the `storybook_compiled` directory.

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
