### PR TITLE
Deprecating BaseIframe scss

### DIFF
--- a/src/scss/components/_BaseIframe.scss
+++ b/src/scss/components/_BaseIframe.scss
@@ -1,3 +1,7 @@
+/* Deprecation warning:
+ * _BaseIframe.scss the BaseIframe class name is deprecated and will be removed in the next major release. Use the TailwindCSS classes directly instead.
+ */
+
 .BaseIframe {
   @apply w-full border-none;
 }

--- a/storybook/stories/components/BaseIframe/BaseIframe.js
+++ b/storybook/stories/components/BaseIframe/BaseIframe.js
@@ -8,7 +8,7 @@ export const BaseIframeTemplate = ({ title, url, height }) => {
     ${height ? `height="${height}"` : ``}
     allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
     allowfullscreen="allowfullscreen"
-    class="BaseIframe"
+    class="w-full border-none"
     src="${url}"
   ></iframe>`
 }


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [x] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

We don't need additional scss for the `BaseIframe` component, as it only applies existing TailwindCSS classes. This PR:
- removes `BaseIframe` CSS class from the `BaseIframe` component and replaces it with equivalent TailwindCSS classes.
- `_BaseIframe.scss` is preserved but with an added deprecation notice. 

## Migration Guide

The `.BaseIframe` css class is now deprecated and will be removed in the next major release. Please update your `BaseIframe` and `BlockIframeEmbed` templates to match. Replace `<iframe class="BaseIframe"...` with `<iframe class="w-full border-none"...`.

### A la carte users

The `_BaseIframe.scss` file is deprecated and will be removed in the next major release. To prepare for the next major release, you should no longer import this file, and update your templates as noted above.

## Instructions to test

1. `npm run storybook`
2. Check the `BaseIframe` and `BlockIframeEmbed` components and make sure it has no perceivable difference.


## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [x] Firefox
- [x] Safari
- [ ] Edge
