### PR TITLE
Removing engines defined in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,6 @@
     "type": "git",
     "url": "https://github.com/nasa-jpl/explorer-1"
   },
-  "engines": {
-    "node": "14.19.0",
-    "npm": "^6.14.16"
-  },
   "scripts": {
     "start": "npm run dev",
     "dev": "run-p watch browsersync",


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

This PR removes the engines added in https://github.com/nasa-jpl/explorer-1/pull/186. We only really need them defined in `.nvmrc` for our actions to work properly, and defining the engines in `package.json` has proven problematic in our other projects. I decided to remove the engines rather than generalize them, as the custom code in Explorer 1 isn't engine specific, though some of its dependencies could be. When that's the case, console warnings will gives users a heads up.

## Instructions to test

Not sure of the best way to test this, but at after this branch is merged, check the setup-node action and make sure it runs without issue.

