### PR TITLE
Set `tracking-normal` explicitly on H4 and H5 styles

### DIFF
--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -103,7 +103,7 @@ h3,
 
 h4,
 .text-h4 {
-  @apply font-semibold text-3xl;
+  @apply font-semibold text-3xl tracking-normal;
   line-height: 1.75rem; // 28px
 
   @screen md {
@@ -121,7 +121,7 @@ h4,
 
 h5,
 .text-h5 {
-  @apply font-semibold text-xl;
+  @apply font-semibold text-xl tracking-normal;
   line-height: 1.625rem; // 26px
 
   @screen md {


### PR DESCRIPTION
### Checklist

- [ ] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.


## Description

I discovered an issue with our current heading styling while working on nasa-jpl/www-frontend#1396: The tighter tracking on bare heading elements `h1`, `h2`, and `h3` overrides the intended normal tracking of the H4 and H5 styles when applying them to those heading elements with the `text-h4` or `text-h5` classes. When those classes are used, the tracking should match the specified H4 and H5 styles.

This adds explicit `tracking-normal` declarations to the `h4, .text-h4` and `h5, .text-h5` rulesets' `@apply` directives, so that the resulting `letter-spacing` properties of the classes will override the `letter-spacing` properties of the `h1`, `h2`, and `h3` elements.

### Screenshots with heading levels 2–5, each with `class="text-h5"`:

#### Before

![Headings 2 through 5 before the fix](https://user-images.githubusercontent.com/1044670/175123593-0df05711-c817-4f4a-beaa-978157291dc9.png)

#### After

![Headings 2 through 5 after the fix](https://user-images.githubusercontent.com/1044670/175124810-bb635431-ecb1-46c6-8c94-173c8a9c2656.png)


## Instructions to test

Uhhh… please hold for the ability to create headings of different levels in nasa-jpl/www-backend#875 :) Or test it using that branch and by manually adding `letter-spacing: 0` to the `h5, .text-h5` ruleset in your dev tools.


## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
