### PR TITLE
fix: adding icon-only flag to image carousel buttons

### DIFF
--- a/storybook/stories/components/BlockImageCarousel/BlockImageCarousel.js
+++ b/storybook/stories/components/BlockImageCarousel/BlockImageCarousel.js
@@ -47,12 +47,14 @@ export const BlockImageCarouselTemplate = ({
               cssClass: 'z-10 border-collapse px-1 py-2 swiper-prev xl:text-xl',
               icon: 'prev',
               label: 'Previous slide',
+              iconOnly: true,
             })}
             ${BaseButtonTemplate({
               variant: 'primary',
               cssClass: 'z-10 border-collapse px-1 py-2 swiper-next xl:text-xl',
               icon: 'next',
               label: 'Next slide',
+              iconOnly: true,
             })}
           </div>
         </div>


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Fixes a regression from #277. It was already fixed for some buttons in [this commit](https://github.com/nasa-jpl/explorer-1/pull/277/commits/13fab53aedb3a804d68c92f45f0a9da643536a4d) but I missed the image carousel buttons. This PR covers that.

## Instructions to test

1. Run storybook
2. Make sure you don't see the button text labels when viewing an image carousel.

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
