### PR TITLE
adjusting dependencies for explorer-1/common

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 /* eslint-disable prettier/prettier */
 // eslint.config.js
+// imports config from the shared eslint-config package `packages/configs/eslint`
 import config from '@explorer-1/eslint-config'
 
 export default [

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@explorer-1/common",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": false,
   "publishConfig": {
     "access": "public"
@@ -15,12 +15,12 @@
   "devDependencies": {
     "@explorer-1/prettier-config": "workspace:*",
     "@explorer-1/tsconfig": "workspace:*",
-    "@tailwindcss/forms": "^0.5.7",
     "stylelint": "^16.5.0",
-    "stylelint-config-standard-scss": "^13.1.0",
-    "tailwindcss": "^3.4.3"
+    "stylelint-config-standard-scss": "^13.1.0"
   },
   "dependencies": {
+    "tailwindcss": "^3.4.3",
+    "@tailwindcss/forms": "^0.5.7",
     "tailwindcss-themer": "^4.0.0"
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@explorer-1/vue",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/vue/src/utils/dayjs.js
+++ b/packages/vue/src/utils/dayjs.js
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs'
-import updateLocale from 'dayjs/plugin/updateLocale'
-import localizedFormat from 'dayjs/plugin/localizedFormat'
-import timezone from 'dayjs/plugin/timezone'
-import advancedFormat from 'dayjs/plugin/advancedFormat'
+import updateLocale from 'dayjs/plugin/updateLocale.js'
+import localizedFormat from 'dayjs/plugin/localizedFormat.js'
+import timezone from 'dayjs/plugin/timezone.js'
+import advancedFormat from 'dayjs/plugin/advancedFormat.js'
 
 // Locales must be imported manually
 // see https://github.com/iamkun/dayjs/tree/dev/src/locale

--- a/packages/vue/src/utils/dayjs.js
+++ b/packages/vue/src/utils/dayjs.js
@@ -6,7 +6,7 @@ import advancedFormat from 'dayjs/plugin/advancedFormat.js'
 
 // Locales must be imported manually
 // see https://github.com/iamkun/dayjs/tree/dev/src/locale
-import 'dayjs/locale/en-gb'
+import 'dayjs/locale/en-gb.js'
 
 dayjs.extend(localizedFormat)
 dayjs.extend(updateLocale)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,12 @@ importers:
 
   packages/common:
     dependencies:
+      '@tailwindcss/forms':
+        specifier: ^0.5.7
+        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)))
+      tailwindcss:
+        specifier: ^3.4.3
+        version: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
       tailwindcss-themer:
         specifier: ^4.0.0
         version: 4.0.0(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)))
@@ -263,18 +269,12 @@ importers:
       '@explorer-1/tsconfig':
         specifier: workspace:*
         version: link:../configs/tsconfig
-      '@tailwindcss/forms':
-        specifier: ^0.5.7
-        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)))
       stylelint:
         specifier: ^16.5.0
         version: 16.6.1(typescript@5.4.5)
       stylelint-config-standard-scss:
         specifier: ^13.1.0
         version: 13.1.0(postcss@8.4.38)(stylelint@16.6.1(typescript@5.4.5))
-      tailwindcss:
-        specifier: ^3.4.3
-        version: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
 
   packages/common-storybook:
     devDependencies:


### PR DESCRIPTION
- Moving tailwindcss from `devDependencies` to `dependencies` in `@explorer-1/common`
- adding file type endings to dayjs imports in @explorer-1/vue