### PR TITLE
Fix/dayjs default export

### DIFF
--- a/packages/vue/src/components/CalendarButton/CalendarButton.vue
+++ b/packages/vue/src/components/CalendarButton/CalendarButton.vue
@@ -16,7 +16,7 @@ import { defineComponent } from 'vue'
 import { ICalendar } from 'datebook'
 import type { CalendarOptions } from 'datebook'
 // @ts-ignore
-import dayjs from 'dayjs'
+import * as dayjs from 'dayjs'
 import BaseButton from './../BaseButton/BaseButton.vue'
 
 export default defineComponent({

--- a/packages/vue/src/components/MissionDetailStats/DistanceStats.vue
+++ b/packages/vue/src/components/MissionDetailStats/DistanceStats.vue
@@ -31,7 +31,7 @@
 // @ts-nocheck
 import type { PropType } from 'vue'
 import { defineComponent } from 'vue'
-import dayjs from 'dayjs'
+import * as dayjs from 'dayjs'
 import BaseUnitToggle, { UnitSystemName } from './../BaseUnitToggle/BaseUnitToggle.vue'
 
 export const distanceTypes = {

--- a/packages/vue/src/components/SearchResultsList/SearchResultsList.vue
+++ b/packages/vue/src/components/SearchResultsList/SearchResultsList.vue
@@ -57,7 +57,7 @@
 import { defineComponent } from 'vue'
 import type { ElasticSearchPage } from '../../interfaces'
 // @ts-ignore
-import dayjs from 'dayjs'
+import * as dayjs from 'dayjs'
 import SearchResultCard from './../SearchResultCard/SearchResultCard.vue'
 import SearchResultGridItem from './../SearchResultGridItem/SearchResultGridItem.vue'
 


### PR DESCRIPTION
changes `import dayjs from 'dayjs'` to `import * as dayjs from 'dayjs'` to fix 

`DAYJS@1.11.11/NODE_MODULES/DAYJS/PLUGIN/ADVANCEDFORMAT.JS?V=8016E08E' DOES NOT PROVIDE AN EXPORT NAMED 'DEFAULT'`