### PR TITLE
Fix: changing strategy when using `text-subtitle` with `@apply` in `_BlockTable.scss`

### DIFF
--- a/packages/common/src/scss/_typography.scss
+++ b/packages/common/src/scss/_typography.scss
@@ -188,13 +188,15 @@
     }
   }
 
-  .text-subtitle {
-    @apply font-secondary uppercase text-base leading-tight tracking-wider;
-  }
+  // moved to a tailwind plugin in tailwind.config.js which allows us to @apply text-subtitle
+  // .text-subtitle {
+  //   @apply font-secondary uppercase text-base leading-tight tracking-wider;
+  // }
 
-  .text-subtitle-sm {
-    @apply font-secondary uppercase text-sm leading-tight tracking-wider;
-  }
+  // moved to a tailwind plugin in tailwind.config.js which allows us to @apply text-subtitle
+  // .text-subtitle-sm {
+  //   @apply font-secondary uppercase text-sm leading-tight tracking-wider;
+  // }
 
   .text-body-lg {
     font-size: pxToRem(18); // Based on Tailwind's text-lg

--- a/packages/common/src/scss/components/_BlockTable.scss
+++ b/packages/common/src/scss/components/_BlockTable.scss
@@ -1,3 +1,6 @@
+// needed to @extend .BlockText
+@import '@explorer-1/common/src/scss/components/BlockText';
+
 .BlockTable {
   table {
     @apply border-gray-light-mid border-t border-b border-collapse w-full;
@@ -8,7 +11,7 @@
   }
 
   th {
-    @apply p-3 lg:p-5 border-gray-light-mid border-b text-subtitle text-white text-left font-normal;
+    @apply p-3 lg:p-5 border-gray-light-mid border-b font-secondary uppercase text-base leading-tight tracking-wider text-white text-left font-normal;
   }
 
   tbody {

--- a/packages/common/tailwind.config.ts
+++ b/packages/common/tailwind.config.ts
@@ -283,6 +283,13 @@ export default {
     require('@tailwindcss/forms'),
     plugin(({ addBase }) => {
       addBase({
+        // reusable typography classes TODO: write a more robust way to include most typography classes
+        '.text-subtitle': {
+          '@apply font-secondary uppercase text-base leading-tight tracking-wider': {}
+        },
+        '.text-subtitle-sm': {
+          '@apply font-secondary uppercase text-sm leading-tight tracking-wider': {}
+        },
         // www theme selectors
         ':root, .ThemeVariantLight': ThemeWww.default,
         '.ThemeVariantDark': ThemeWww.dark,

--- a/packages/vue/src/components/BlockTable/BlockTable.vue
+++ b/packages/vue/src/components/BlockTable/BlockTable.vue
@@ -65,9 +65,5 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import '@explorer-1/common/src/scss/typography';
-// required for @apply text-subtitle in _BlockTable.scss
-@import '@explorer-1/common/src/scss/components/BlockText';
-// required for @extend .BlockText in _BlockTable.scss
 @import '@explorer-1/common/src/scss/components/BlockTable';
 </style>


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

`_BlockTable.scss` was originally importing all of `typography.scss` to be able to use the `.text-subtitle` class in an `@apply` statement.

This was, in turn,  re-importing base tailwind config styles, with vite rewriting the paths relative the scss file. The styles generated by `_BlockTable.scss` were overriding the original base styles, which also explains why you might get flashes of styled/unstyled content.

- Fixes star backgrounds in edu
- Fixes repetitive flashing of styled/unstyled content

## Instructions to test

Difficult to test as `www` currently won't work locally. I tested by checking out an older commit of www and running `make build-frontend` in the www repo while using a local version of Explorer-1. When searching `.output` for `../explorer-1/bg-stars-edu.png`, there were no matches.

Before testing, you might want to test `main` in the same way. You should get results when searching for `../explorer-1/bg-stars-edu.png`.

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
