### PR TITLE
fix: share buttons on edu content pages

### DIFF
--- a/packages/vue/src/templates/PageContent/PageContent.vue
+++ b/packages/vue/src/templates/PageContent/PageContent.vue
@@ -1,12 +1,16 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import { useRoute } from 'vue-router'
+import { mapStores } from 'pinia'
+import { useThemeStore } from '../../store/theme'
+
 import HeroMedia from '@explorer-1/vue/src/components/HeroMedia/HeroMedia.vue'
 import NavSecondary from '@explorer-1/vue/src/components/NavSecondary/NavSecondary.vue'
 import LayoutHelper from '@explorer-1/vue/src/components/LayoutHelper/LayoutHelper.vue'
 import DetailHeadline from '@explorer-1/vue/src/components/DetailHeadline/DetailHeadline.vue'
 import BlockImageStandard from '@explorer-1/vue/src/components/BlockImage/BlockImageStandard.vue'
 import ShareButtons from '@explorer-1/vue/src/components/ShareButtons/ShareButtons.vue'
+import ShareButtonsEdu from '@explorer-1/vue/src/components/ShareButtonsEdu/ShareButtonsEdu.vue'
 import BlockStreamfield from '@explorer-1/vue/src/components/BlockStreamfield/BlockStreamfield.vue'
 import BlockRelatedLinks from '@explorer-1/vue/src/components/BlockRelatedLinks/BlockRelatedLinks.vue'
 import FormContact from '@explorer-1/vue/src/components/FormContact/FormContact.vue'
@@ -24,6 +28,7 @@ export default defineComponent({
     DetailHeadline,
     BlockImageStandard,
     ShareButtons,
+    ShareButtonsEdu,
     BlockStreamfield,
     BlockRelatedLinks,
     FormContact,
@@ -38,6 +43,10 @@ export default defineComponent({
     }
   },
   computed: {
+    ...mapStores(useThemeStore),
+    isEdu() {
+      return this.themeStore.theme === 'ThemeEdu'
+    },
     heroInline() {
       if (this.data?.heroPosition === 'inline') {
         return true
@@ -92,6 +101,13 @@ export default defineComponent({
         :label="data.displayLabel"
         :class="{ 'sr-only': hideH1 }"
       />
+      <ShareButtonsEdu
+        v-if="isEdu && data?.url"
+        class="mt-4"
+        :url="data.url"
+        :title="data.title"
+        :image="data.thumbnailImage?.original"
+      />
     </LayoutHelper>
 
     <!-- inline hero -->
@@ -114,7 +130,7 @@ export default defineComponent({
       class="lg:mb-0 relative mb-8"
     >
       <ShareButtons
-        v-if="data.title && data.url"
+        v-if="data.title && data.url && !isEdu"
         :title="data.title"
         :url="data.url"
       />

--- a/packages/vue/src/templates/edu/PageContentEdu.stories.js
+++ b/packages/vue/src/templates/edu/PageContentEdu.stories.js
@@ -1,0 +1,31 @@
+import { ContentPageData } from './../PageContent/PageContent.stories.js'
+import PageContent from './../PageContent/PageContent.vue'
+
+export default {
+  title: 'Templates/EDU/PageContent',
+  component: PageContent,
+  decorators: [
+    () => ({
+      template: `<div id="storyDecorator" class="ThemeEdu"><story/></div>`
+    })
+  ],
+  parameters: {
+    html: {
+      root: '#storyDecorator'
+    },
+    docs: {
+      description: {
+        component:
+          'EDU uses the same `PageContent` component as WWW. The only difference is the theme class used on the site.'
+      }
+    }
+  },
+  excludeStories: /.*(Data)$/
+}
+
+// stories
+export const BaseStory = {
+  args: {
+    data: ContentPageData
+  }
+}

--- a/packages/vue/src/templates/edu/PageEduNewsDetail.vue
+++ b/packages/vue/src/templates/edu/PageEduNewsDetail.vue
@@ -101,7 +101,7 @@ const dateTimeArray = computed(() => {
         :topics="data.getTopicsForDisplay"
         schema
       />
-      <share-buttons-edu
+      <ShareButtonsEdu
         v-if="data?.url"
         class="mt-4"
         :url="data.url"


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [x] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Fixes the `PageContent` component to use EDU share buttons when using the EDU theme.

## Instructions to test

Chromatic links coming soon

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [x] Firefox
- [ ] Safari
- [ ] Edge
