### PR TITLE
Fix: secondary nav z-index, main edu nav styles

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@explorer-1/vue",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/vue/src/components/NavDesktopEdu/NavDesktopEdu.vue
+++ b/packages/vue/src/components/NavDesktopEdu/NavDesktopEdu.vue
@@ -67,7 +67,7 @@
             </button>
             <div
               v-else
-              class="flex items-center w-full"
+              class="flex items-center w-full -transparent"
             >
               <NavSearchForm
                 class="w-full"

--- a/packages/vue/src/components/NavDesktopEdu/NavDesktopEdu.vue
+++ b/packages/vue/src/components/NavDesktopEdu/NavDesktopEdu.vue
@@ -8,13 +8,11 @@
       'transition-transform': scrollTop > 0 && scrolledCurrentPage, // If not at the top of the page, just transition the transform to prevents content from peeking through on header reveal.
       'transform -translate-y-full': !scrolledUp && !headerVisible,
       '-scrolled transform translate-y-0': scrolledUp && headerVisible && scrollTop > 0,
-      '-transparent': invert,
       '-hasSecondary': !headerStore?.highlightPrimary
     }"
   >
     <!-- navbar -->
     <div class="header-bg z-10 max-w-screen-3xl absolute inset-0 mx-auto"></div>
-    <div class="bg-primary z-0 absolute right-0 w-1/2 top-0 bottom-0"></div>
     <div class="px-4">
       <div class="h-18 container flex items-center justify-between mx-auto">
         <!-- branding -->
@@ -69,7 +67,7 @@
             </button>
             <div
               v-else
-              class="flex items-center w-full -transparent"
+              class="flex items-center w-full"
             >
               <NavSearchForm
                 class="w-full"
@@ -285,30 +283,6 @@ export default defineComponent({
         // mimics .text-contrast class
         text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.7);
       }
-    }
-  }
-
-  &.-scrolled {
-    @apply border-b border-gray-mid border-opacity-50 bg-white;
-
-    &.-transparent {
-      > .header-bg {
-        @apply opacity-0 bg-white;
-      }
-
-      .main-navigation {
-        > * {
-          @apply text-gray-dark;
-
-          .NavDesktopDropdown > button {
-            text-shadow: none;
-          }
-        }
-      }
-    }
-
-    &.-hasSecondary {
-      @apply border-0 border-transparent;
     }
   }
 }

--- a/packages/vue/src/components/NavSecondary/NavSecondary.vue
+++ b/packages/vue/src/components/NavSecondary/NavSecondary.vue
@@ -139,7 +139,7 @@ export default defineComponent({
 <style lang="scss">
 .NavSecondary {
   top: -1px; // for intersection observer to work
-  @apply sticky z-50 w-full bg-white border-b border-gray-mid border-opacity-0 transition-border-opacity duration-150 ease-in;
+  @apply sticky z-50 w-full bg-white border-b edu:border-0 border-gray-mid border-opacity-0 transition-border-opacity duration-150 ease-in;
   @apply hidden;
   @screen lg {
     @apply block;


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

- Fixes the z-index on secondary nav menus to not overlap main menu dropdowns.
- Fixes some styles for the main nav in the EDU theme

## Instructions to test

<!-- Provide instructions on how a reviewer can verify your work. -->

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
