### PR TITLE
fix: secondary nav offset, dayjs import in utils/filters.js

### DIFF
--- a/packages/vue/src/components/NavSecondary/NavSecondary.vue
+++ b/packages/vue/src/components/NavSecondary/NavSecondary.vue
@@ -139,7 +139,7 @@ export default defineComponent({
 <style lang="scss">
 .NavSecondary {
   top: -1px; // for intersection observer to work
-  @apply sticky z-50 w-full bg-white border-b edu:border-0 border-gray-mid border-opacity-0 transition-border-opacity duration-150 ease-in;
+  @apply sticky z-40 w-full bg-white border-b edu:border-0 border-gray-mid border-opacity-0 transition-border-opacity duration-150 edu:duration-300 ease-in;
   @apply hidden;
   @screen lg {
     @apply block;
@@ -184,8 +184,14 @@ export default defineComponent({
       }
     }
     @screen lg {
-      @apply top-28 edu:top-18;
+      @apply top-28;
     }
+  }
+}
+// since we depend on a body class, the edu: prefix won't work as usual and requires the below line
+body.header-sticky-showing .ThemeEdu .NavSecondary {
+  @screen lg {
+    @apply top-[4.45rem];
   }
 }
 </style>

--- a/packages/vue/src/utils/filters.js
+++ b/packages/vue/src/utils/filters.js
@@ -1,4 +1,5 @@
-import dayjs from './dayjs'
+// must include `.js`
+import dayjs from './dayjs.js'
 
 const filters = {
   // To support more locales update add imports to dayjs.js'


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Supports https://github.com/nasa-jpl/www/issues/244

## Instructions to test

- difficult to test without using the www frontend app (requires publishing the npm package for general testing).
- to test locally, you can follow [these instructions](https://github.com/nasa-jpl/www?tab=readme-ov-file#working-on-explorer-1-components) to reference your local copy of explorer-1. Then:
1. `make backend`
2. `make frontend`
3. make a content page and check "override secondary navigation"
4. create child pages and check "show in menus"
5. view the first content page you made on the frontend. You should see the secondary navigation stick to the top when scrolling. When scrolling back up, the main nav should appear, and the secondary nav should be offset just enough.

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
