### PR TITLE
feature: MetaPanel, BlockAccordion, EduLessonPage

### DIFF
--- a/apps/vue-storybook/.storybook/preview.ts
+++ b/apps/vue-storybook/.storybook/preview.ts
@@ -6,6 +6,7 @@ import { createRouter, createWebHashHistory, type RouterOptions } from 'vue-rout
 import { Swiper, SwiperSlide } from 'swiper/vue'
 import vClickOutside from 'click-outside-vue3'
 import VueCompareImage from 'vue3-compare-image'
+import { BindOncePlugin } from 'vue-bind-once'
 import { createPinia } from 'pinia'
 import filters from '@explorer-1/vue/src/utils/filters'
 import '@explorer-1/common/src/scss/styles-with-fonts.scss'
@@ -38,6 +39,7 @@ setup((app, _context) => {
   app.use(router)
   app.use(vClickOutside)
   app.use(VueCompareImage)
+  app.use(BindOncePlugin)
   app.component('Swiper', Swiper)
   app.component('SwiperSlide', SwiperSlide)
   app.config.globalProperties.$filters = filters

--- a/apps/vue-storybook/package.json
+++ b/apps/vue-storybook/package.json
@@ -44,6 +44,7 @@
     "mitt": "^3.0.1",
     "swiper": "^11.1.3",
     "vue": "^3.2.47",
+    "vue-bind-once": "^0.2.1",
     "vue3-compare-image": "^1.2.5"
   },
   "devDependencies": {

--- a/packages/common/src/scss/_grid.scss
+++ b/packages/common/src/scss/_grid.scss
@@ -6,27 +6,27 @@
 
   .MixedBleedGrid {
     @screen sm {
-      grid-template-columns: [bleed-start] auto [container-start] 53.33px [indent-col-2] 53.33px [indent-col-3] 533.33px [container-end] auto [bleed-end];
+      grid-template-columns: [bleed-start] 1fr [container-start] 53.33px [indent-col-2] 53.33px [indent-col-3] 533.33px [container-end] 1fr [bleed-end];
       @apply grid gap-0;
     }
 
     @screen md {
-      grid-template-columns: [bleed-start] auto [container-start] 64px [indent-col-2] 64px [indent-col-3] 640px [container-end] auto [bleed-end];
+      grid-template-columns: [bleed-start] 1fr [container-start] 64px [indent-col-2] 64px [indent-col-3] 640px [container-end] 1fr [bleed-end];
       @apply grid;
     }
 
     @screen lg {
-      grid-template-columns: [bleed-start] auto [container-start] 85.33px [indent-col-2] 85.33px [indent-col-3] 853.33px [container-end] auto [bleed-end];
+      grid-template-columns: [bleed-start] 1fr [container-start] 85.33px [indent-col-2] 85.33px [indent-col-3] 853.33px [container-end] 1fr [bleed-end];
       @apply grid;
     }
 
     @screen xl {
-      grid-template-columns: [bleed-start] auto [container-start] 108px [indent-col-2] 108px [indent-col-3] 1088px [container-end] auto [bleed-end];
+      grid-template-columns: [bleed-start] 1fr [container-start] 108px [indent-col-2] 108px [indent-col-3] 1088px [container-end] 1fr [bleed-end];
       @apply grid;
     }
 
     @screen 2xl {
-      grid-template-columns: [bleed-start] auto [container-start] 110px [indent-col-2] 110px [indent-col-3] 1100px [container-end] auto [bleed-end];
+      grid-template-columns: [bleed-start] 1fr [container-start] 110px [indent-col-2] 110px [indent-col-3] 1100px [container-end] 1fr [bleed-end];
       @apply grid;
     }
 

--- a/packages/common/src/scss/_grid.scss
+++ b/packages/common/src/scss/_grid.scss
@@ -42,6 +42,10 @@
       grid-column-start: container-start;
     }
 
+    .col-start-indent-col-1 {
+      grid-column-start: indent-col-1;
+    }
+
     .col-start-indent-col-2 {
       grid-column-start: indent-col-2;
     }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -38,6 +38,7 @@
     "tailwindcss": "^3.4.3",
     "twitter-widgets": "^2.0.0",
     "vue": "^3.4.21",
+    "vue-bind-once": "^0.2.1",
     "vue-observe-visibility": "^1.0.0",
     "vue3-compare-image": "^1.2.5"
   },

--- a/packages/vue/src/components/BaseAccordionItem/BaseAccordionItem.stories.js
+++ b/packages/vue/src/components/BaseAccordionItem/BaseAccordionItem.stories.js
@@ -1,0 +1,15 @@
+import BaseAccordionItem from './BaseAccordionItem.vue'
+import { BlockStreamfieldTruncatedData } from '../BlockStreamfield/BlockStreamfield.stories'
+export default {
+  title: 'Components/Base/BaseAccordionItem',
+  component: BaseAccordionItem
+}
+
+// stories
+export const BaseStory = {
+  name: 'BaseAccordionItem',
+  args: {
+    headingLevel: 'h3',
+    accordionItem: { title: 'Title for the accordion', body: BlockStreamfieldTruncatedData.body }
+  }
+}

--- a/packages/vue/src/components/BaseAccordionItem/BaseAccordionItem.stories.js
+++ b/packages/vue/src/components/BaseAccordionItem/BaseAccordionItem.stories.js
@@ -10,6 +10,6 @@ export const BaseStory = {
   name: 'BaseAccordionItem',
   args: {
     headingLevel: 'h3',
-    accordionItem: { title: 'Title for the accordion', body: BlockStreamfieldTruncatedData.body }
+    item: { title: 'Title for the accordion', body: BlockStreamfieldTruncatedData.body }
   }
 }

--- a/packages/vue/src/components/BaseAccordionItem/BaseAccordionItem.vue
+++ b/packages/vue/src/components/BaseAccordionItem/BaseAccordionItem.vue
@@ -2,17 +2,19 @@
 import { computed, reactive, ref } from 'vue'
 import { AccordionItemObject } from './../../interfaces.ts'
 import { uniqueId } from 'lodash'
-import IconClose from './../Icons/IconClose.vue'
+import IconPlus from './../Icons/IconPlus.vue'
 import BlockStreamfield from './../BlockStreamfield/BlockStreamfield.vue'
 
 export interface BaseAccordionItemProps {
   headingLevel?: string
   item: AccordionItemObject
+  backgroundClass?: string
 }
 
 // define props
 const props = withDefaults(defineProps<BaseAccordionItemProps>(), {
   headingLevel: 'h2',
+  backgroundClass: undefined,
   item(): AccordionItemObject {
     return {
       title: undefined,
@@ -48,33 +50,34 @@ const handleClick = () => {
 const emit = defineEmits(['accordionItemOpened', 'accordionItemClosed'])
 </script>
 <template>
-  <div class="BaseAccordionItem">
-    <div class="BlockAccordionHeader">
+  <div
+    class="BaseAccordionItem"
+    :class="{ '-open': !isHidden }"
+  >
+    <div class="BaseAccordionHeader">
       <slot name="header">
         <div
           v-if="headingLevel && item"
           class="border-b border-gray-light-mid"
         >
-          <component
-            :is="headingLevel"
-            class="text-body-lg"
-          >
+          <component :is="headingLevel">
             <button
               :id="headingId"
               :aria-expanded="ariaExpanded"
-              class="BlockAccordion-trigger group flex flex-nowrap justify-between items-center w-full p-4 xl:py-6 can-hover:hover:underline focus:outline-none focus:underline"
+              class="BaseAccordion-trigger group flex flex-nowrap justify-between items-center w-full can-hover:hover:underline text-body-lg"
               :aria-controls="panelId"
               @click="handleClick()"
             >
-              <span class="pointer-events-none text-left pr-4">
-                {{ item.title }}
-              </span>
-
+              <slot name="heading">
+                <div class="pointer-events-none text-left p-4 xl:py-6">
+                  {{ item.title }}
+                </div>
+              </slot>
               <span
-                class="BlockAccordion-icon pointer-events-none text-xs text-action flex-shrink-0 transform transition-transform"
-                :class="{ 'rotate-45': isHidden }"
+                class="BaseAccordion-icon pointer-events-none text-xs text-action flex-shrink-0 transform transition-transform"
+                :class="{ 'rotate-45': !isHidden }"
               >
-                <IconClose />
+                <IconPlus />
               </span>
             </button>
           </component>
@@ -83,21 +86,23 @@ const emit = defineEmits(['accordionItemOpened', 'accordionItemClosed'])
     </div>
     <div
       v-show="!isHidden"
-      class="BlockAccordionContent"
+      class="BaseAccordionContent"
     >
       <slot>
         <div
           :id="panelId"
           role="region"
           :aria-labelledby="headingId"
-          class="BlockAccordion-panel"
+          class="BaseAccordion-panel"
         >
-          <div class="px-4 pb-8">
-            <BlockStreamfield
-              :data="item.body"
-              variant="fluid"
-            />
-          </div>
+          <slot name="panelContents">
+            <div class="px-4 pb-8">
+              <BlockStreamfield
+                :data="item.body"
+                variant="fluid"
+              />
+            </div>
+          </slot>
         </div>
       </slot>
     </div>

--- a/packages/vue/src/components/BaseAccordionItem/BaseAccordionItem.vue
+++ b/packages/vue/src/components/BaseAccordionItem/BaseAccordionItem.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue'
+import { AccordionItemObject } from './../../interfaces.ts'
+import { uniqueId } from 'lodash'
+import IconClose from './../Icons/IconClose.vue'
+import BlockStreamfield from './../BlockStreamfield/BlockStreamfield.vue'
+
+export interface BaseAccordionItemProps {
+  headingLevel?: string
+  item: AccordionItemObject
+}
+
+// define props
+const props = withDefaults(defineProps<BaseAccordionItemProps>(), {
+  headingLevel: 'h2',
+  item(): AccordionItemObject {
+    return {
+      title: undefined,
+      body: undefined
+    }
+  }
+})
+
+const { headingLevel, item } = reactive(props)
+
+const ariaExpanded = ref(false)
+const isHidden = ref(true)
+const itemId = ref(uniqueId())
+
+const panelId = computed(() => {
+  return `block_accordion_panel_${itemId.value}`
+})
+
+const headingId = computed(() => {
+  return `block_accordion_heading_${itemId.value}`
+})
+
+const handleClick = () => {
+  ariaExpanded.value = !ariaExpanded.value
+  isHidden.value = !isHidden.value
+  if (isHidden.value) {
+    emit('accordionItemClosed')
+  } else {
+    emit('accordionItemOpened')
+  }
+}
+
+const emit = defineEmits(['accordionItemOpened', 'accordionItemClosed'])
+</script>
+<template>
+  <div class="BaseAccordionItem">
+    <div class="BlockAccordionHeader">
+      <slot name="header">
+        <div
+          v-if="headingLevel && item"
+          class="border-b border-gray-light-mid"
+        >
+          <component
+            :is="headingLevel"
+            class="text-body-lg"
+          >
+            <button
+              :id="headingId"
+              :aria-expanded="ariaExpanded"
+              class="BlockAccordion-trigger group flex flex-nowrap justify-between items-center w-full p-4 xl:py-6 can-hover:hover:underline focus:outline-none focus:underline"
+              :aria-controls="panelId"
+              @click="handleClick()"
+            >
+              <span class="pointer-events-none text-left pr-4">
+                {{ item.title }}
+              </span>
+
+              <span
+                class="BlockAccordion-icon pointer-events-none text-xs text-action flex-shrink-0 transform transition-transform"
+                :class="{ 'rotate-45': isHidden }"
+              >
+                <IconClose />
+              </span>
+            </button>
+          </component>
+        </div>
+      </slot>
+    </div>
+    <div
+      v-show="!isHidden"
+      class="BlockAccordionContent"
+    >
+      <slot>
+        <div
+          :id="panelId"
+          role="region"
+          :aria-labelledby="headingId"
+          class="BlockAccordion-panel"
+        >
+          <div class="px-4 pb-8">
+            <BlockStreamfield
+              :data="item.body"
+              variant="fluid"
+            />
+          </div>
+        </div>
+      </slot>
+    </div>
+  </div>
+</template>

--- a/packages/vue/src/components/BaseAccordionItem/BaseAccordionItem.vue
+++ b/packages/vue/src/components/BaseAccordionItem/BaseAccordionItem.vue
@@ -62,10 +62,9 @@ const emit = defineEmits(['accordionItemOpened', 'accordionItemClosed'])
         >
           <component :is="headingLevel">
             <button
-              :id="headingId"
+              v-bind-once="{ id: headingId, 'aria-controls': panelId }"
               :aria-expanded="ariaExpanded"
               class="BaseAccordion-trigger group flex flex-nowrap justify-between items-center w-full can-hover:hover:underline text-body-lg"
-              :aria-controls="panelId"
               @click="handleClick()"
             >
               <slot name="heading">
@@ -90,9 +89,8 @@ const emit = defineEmits(['accordionItemOpened', 'accordionItemClosed'])
     >
       <slot>
         <div
-          :id="panelId"
+          v-bind-once="{ id: panelId, 'aria-labelledby': headingId }"
           role="region"
-          :aria-labelledby="headingId"
           class="BaseAccordion-panel"
         >
           <slot name="panelContents">

--- a/packages/vue/src/components/BaseButton/BaseButton.vue
+++ b/packages/vue/src/components/BaseButton/BaseButton.vue
@@ -11,6 +11,11 @@ export const variants: Variants = {
   dark: '-dark',
   social: '-social'
 }
+export const colors: Variants = {
+  primary: '-color-primary',
+  secondary: '-color-secondary',
+  action: '-color-action'
+}
 
 export default defineComponent({
   name: 'BaseButton',
@@ -20,6 +25,12 @@ export default defineComponent({
       required: false,
       default: 'primary',
       validator: (prop: string): boolean => Object.keys(variants).includes(prop)
+    },
+    color: {
+      type: String,
+      required: false,
+      default: 'primary',
+      validator: (prop: string): boolean => Object.keys(colors).includes(prop)
     },
     compact: {
       type: Boolean,

--- a/packages/vue/src/components/BaseButton/BaseButton.vue
+++ b/packages/vue/src/components/BaseButton/BaseButton.vue
@@ -2,7 +2,7 @@
 import { defineComponent } from 'vue'
 
 interface Variants {
-  [name: string]: string
+  [key: string]: string
 }
 
 export const variants: Variants = {

--- a/packages/vue/src/components/BaseImage/BaseImage.vue
+++ b/packages/vue/src/components/BaseImage/BaseImage.vue
@@ -5,7 +5,7 @@ import type { PropType } from 'vue'
 export type ImageLoader = 'lazy' | 'eager' | undefined
 
 interface ObjectFitClasses {
-  [name: string]: string
+  [key: string]: string
 }
 
 export const objectFitClasses: ObjectFitClasses = {

--- a/packages/vue/src/components/BaseImagePlaceholder/BaseImagePlaceholder.vue
+++ b/packages/vue/src/components/BaseImagePlaceholder/BaseImagePlaceholder.vue
@@ -2,7 +2,7 @@
 import { defineComponent } from 'vue'
 
 interface AspectRatios {
-  [name: string]: string
+  [key: string]: string
 }
 
 export const aspectRatios: AspectRatios = {

--- a/packages/vue/src/components/BaseLink/BaseLink.vue
+++ b/packages/vue/src/components/BaseLink/BaseLink.vue
@@ -4,7 +4,7 @@ import { eventBus } from './../../utils/eventBus'
 import MixinAnimationCaret from './../MixinAnimationCaret/MixinAnimationCaret.vue'
 
 interface Variants {
-  [name: string]: string
+  [key: string]: string
 }
 
 export const variants: Variants = {

--- a/packages/vue/src/components/BlockAccordion/BlockAccordion.stories.js
+++ b/packages/vue/src/components/BlockAccordion/BlockAccordion.stories.js
@@ -1,0 +1,29 @@
+import BlockAccordion from './BlockAccordion.vue'
+import { BlockStreamfieldTruncatedData } from '../BlockStreamfield/BlockStreamfield.stories'
+
+export default {
+  title: 'Components/Blocks/BlockAccordion',
+  component: BlockAccordion
+}
+
+// stories
+export const BaseStory = {
+  name: 'BlockAccordion',
+  args: {
+    headingLevel: 'h5',
+    items: [
+      {
+        title: 'Title for the accordion',
+        body: BlockStreamfieldTruncatedData.body
+      },
+      {
+        title: 'Another',
+        body: BlockStreamfieldTruncatedData.body
+      },
+      {
+        title: 'Yet another',
+        body: BlockStreamfieldTruncatedData.body
+      }
+    ]
+  }
+}

--- a/packages/vue/src/components/BlockAccordion/BlockAccordion.vue
+++ b/packages/vue/src/components/BlockAccordion/BlockAccordion.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { reactive } from 'vue'
+import { AccordionItemObject } from '../../interfaces'
+import BaseAccordionItem from './../BaseAccordionItem/BaseAccordionItem.vue'
+
+interface BlockAccordionProps {
+  autoClose?: boolean
+  headingLevel?: string
+  items?: AccordionItemObject[]
+}
+
+// define props
+const props = withDefaults(defineProps<BlockAccordionProps>(), {
+  autoClose: false,
+  headingLevel: 'h2',
+  items: undefined
+})
+
+const { headingLevel, items } = reactive(props)
+</script>
+<template>
+  <div class="BlockAccordion">
+    <slot>
+      <BaseAccordionItem
+        v-for="(item, index) in items"
+        :key="index"
+        :heading-level="headingLevel"
+        :item="item"
+      />
+    </slot>
+  </div>
+</template>

--- a/packages/vue/src/components/BlockHeading/BlockHeading.stories.js
+++ b/packages/vue/src/components/BlockHeading/BlockHeading.stories.js
@@ -11,7 +11,7 @@ export const BlockHeadingData = {
   heading: 'Heading Text',
   level: 'h2',
   size: 'h2',
-  id: `headingBlock_${uniqueId()}`
+  blockId: `${Math.random().toString(36).slice(2)}`
 }
 
 // stories

--- a/packages/vue/src/components/BlockHeading/BlockHeading.stories.js
+++ b/packages/vue/src/components/BlockHeading/BlockHeading.stories.js
@@ -1,5 +1,4 @@
 import BlockHeading from './BlockHeading.vue'
-import { uniqueId } from 'lodash'
 export default {
   title: 'Components/Blocks/BlockHeading',
   component: BlockHeading,

--- a/packages/vue/src/components/BlockHeading/BlockHeading.stories.js
+++ b/packages/vue/src/components/BlockHeading/BlockHeading.stories.js
@@ -1,5 +1,5 @@
 import BlockHeading from './BlockHeading.vue'
-
+import { uniqueId } from 'lodash'
 export default {
   title: 'Components/Blocks/BlockHeading',
   component: BlockHeading,
@@ -10,7 +10,8 @@ export const BlockHeadingData = {
   blockType: 'HeadingBlock',
   heading: 'Heading Text',
   level: 'h2',
-  size: 'h2'
+  size: 'h2',
+  id: `headingBlock_${uniqueId()}`
 }
 
 // stories

--- a/packages/vue/src/components/BlockHeading/BlockHeading.vue
+++ b/packages/vue/src/components/BlockHeading/BlockHeading.vue
@@ -19,7 +19,7 @@ export interface BlockHeadingObject {
   heading?: string
   level?: string
   size?: string
-  id?: string
+  blockId?: string
 }
 
 export default defineComponent({
@@ -33,11 +33,6 @@ export default defineComponent({
       required: false,
       default: undefined
     },
-    // index: {
-    //   type: Number,
-    //   required: false,
-    //   default: undefined
-    // },
     generateId: {
       type: Boolean,
       default: false
@@ -46,7 +41,7 @@ export default defineComponent({
   computed: {
     getId() {
       return this.data && this.generateId
-        ? getHeadingId(this.data.heading, this.data.id)
+        ? getHeadingId(this.data.heading, this.data.blockId)
         : undefined
     }
   }

--- a/packages/vue/src/components/BlockHeading/BlockHeading.vue
+++ b/packages/vue/src/components/BlockHeading/BlockHeading.vue
@@ -12,12 +12,15 @@
 
 <script lang="ts">
 import { defineComponent, type PropType } from 'vue'
+import { type HeadingLevel } from './../BaseHeading/BaseHeading.vue'
 import { getHeadingId } from '../../utils/getHeadingId'
+
 import BaseHeading from './../BaseHeading/BaseHeading.vue'
 
 export interface BlockHeadingObject {
-  heading?: string
-  level?: string
+  blockType?: string
+  heading: HeadingLevel
+  level?: HeadingLevel
   size?: string
   blockId?: string
 }

--- a/packages/vue/src/components/BlockHeading/BlockHeading.vue
+++ b/packages/vue/src/components/BlockHeading/BlockHeading.vue
@@ -11,9 +11,15 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, type PropType } from 'vue'
 import { getHeadingId } from '../../utils/getHeadingId'
 import BaseHeading from './../BaseHeading/BaseHeading.vue'
+
+export interface BlockHeadingObject {
+  heading?: string
+  level?: string
+  size?: string
+}
 
 export default defineComponent({
   name: 'BlockHeading',
@@ -22,8 +28,9 @@ export default defineComponent({
   },
   props: {
     data: {
-      type: Object,
-      required: false
+      type: Object as PropType<BlockHeadingObject>,
+      required: false,
+      default: undefined
     },
     index: {
       type: Number,

--- a/packages/vue/src/components/BlockHeading/BlockHeading.vue
+++ b/packages/vue/src/components/BlockHeading/BlockHeading.vue
@@ -19,6 +19,7 @@ export interface BlockHeadingObject {
   heading?: string
   level?: string
   size?: string
+  id?: string
 }
 
 export default defineComponent({
@@ -32,11 +33,11 @@ export default defineComponent({
       required: false,
       default: undefined
     },
-    index: {
-      type: Number,
-      required: false,
-      default: undefined
-    },
+    // index: {
+    //   type: Number,
+    //   required: false,
+    //   default: undefined
+    // },
     generateId: {
       type: Boolean,
       default: false
@@ -44,7 +45,9 @@ export default defineComponent({
   },
   computed: {
     getId() {
-      return this.generateId ? getHeadingId(this.data?.heading, this.index) : undefined
+      return this.data && this.generateId
+        ? getHeadingId(this.data.heading, this.data.id)
+        : undefined
     }
   }
 })

--- a/packages/vue/src/components/BlockLinkCarousel/BlockLinkCarousel.vue
+++ b/packages/vue/src/components/BlockLinkCarousel/BlockLinkCarousel.vue
@@ -21,7 +21,7 @@ import BlockLinkCard from './../BlockLinkCard/BlockLinkCard.vue'
 import BlockLinkTile from './../BlockLinkTile/BlockLinkTile.vue'
 
 interface Variants {
-  [name: string]: string
+  [key: string]: string
 }
 
 export const itemTypes: Variants = {

--- a/packages/vue/src/components/BlockRelatedLinks/RelatedLink.vue
+++ b/packages/vue/src/components/BlockRelatedLinks/RelatedLink.vue
@@ -24,7 +24,7 @@ import IconDownload from './../Icons/IconDownload.vue'
 import IconExternal from './../Icons/IconExternal.vue'
 
 interface Variants {
-  [name: string]: string
+  [key: string]: string
 }
 
 export const variants: Variants = {

--- a/packages/vue/src/components/BlockStreamfield/BlockStreamfield.stories.js
+++ b/packages/vue/src/components/BlockStreamfield/BlockStreamfield.stories.js
@@ -54,14 +54,14 @@ export const BlockStreamfieldTruncatedData = {
       value:
         '<p>Lorem ipsum <a href="/missions/test-mission/">dolor</a> sit amet, consectetur adipiscing elit. Quisque vitae justo quis justo malesuada molestie. Cras sed tincidunt dui.</p><p>Integer imperdiet blandit neque vitae euismod. Nulla aliquet lacus nibh,  vel tincidunt urna efficitur non. In et eros vitae ex posuere maximus  quis eget urna. Suspendisse fringilla posuere velit sit amet posuere.  Morbi malesuada bibendum vehicula. Donec faucibus ut erat ut mattis.  Suspendisse ornare, quam at placerat cursus, dolor mi lacinia nunc, eget  maximus augue nulla in dolor.</p>\n'
     },
-    BlockHeadingData,
+    { ...BlockHeadingData, blockId: Math.random().toString(36).slice(2) },
     {
       blockType: 'RichTextBlock',
       value:
         '<p>Lorem ipsum <a href="/missions/test-mission/">dolor</a> sit amet, consectetur adipiscing elit. Quisque vitae justo quis justo malesuada molestie. Cras sed tincidunt dui.</p><p>Integer imperdiet blandit neque vitae euismod. Nulla aliquet lacus nibh,  vel tincidunt urna efficitur non. In et eros vitae ex posuere maximus  quis eget urna. Suspendisse fringilla posuere velit sit amet posuere.  Morbi malesuada bibendum vehicula. Donec faucibus ut erat ut mattis.  Suspendisse ornare, quam at placerat cursus, dolor mi lacinia nunc, eget  maximus augue nulla in dolor.</p>\n'
     },
     BlockImageData,
-    BlockHeadingData,
+    { ...BlockHeadingData, blockId: Math.random().toString(36).slice(2) },
     {
       blockType: 'RichTextBlock',
       value:

--- a/packages/vue/src/components/BlockStreamfield/BlockStreamfield.stories.js
+++ b/packages/vue/src/components/BlockStreamfield/BlockStreamfield.stories.js
@@ -32,24 +32,42 @@ export default {
   excludeStories: /.*(Data)$/
 }
 
+export const BlockStreamfieldMinimalData = {
+  body: [
+    {
+      blockType: 'RichTextBlock',
+      value:
+        '<p>Lorem ipsum <a href="/missions/test-mission/">dolor</a> sit amet, consectetur adipiscing elit. Quisque vitae justo quis justo malesuada molestie. Cras sed tincidunt dui.</p>\n'
+    },
+    {
+      blockType: 'RichTextBlock',
+      value:
+        '<p>Integer imperdiet blandit neque vitae euismod. Nulla aliquet lacus nibh,  vel tincidunt urna efficitur non. In et eros vitae ex posuere maximus  quis eget urna. Suspendisse fringilla posuere velit sit amet posuere.  Morbi malesuada bibendum vehicula. Donec faucibus ut erat ut mattis.  Suspendisse ornare, quam at placerat cursus, dolor mi lacinia nunc, eget  maximus augue nulla in dolor.</p>\n'
+    }
+  ]
+}
 export const BlockStreamfieldTruncatedData = {
   body: [
     BlockKeyPointsData,
+    {
+      blockType: 'RichTextBlock',
+      value:
+        '<p>Lorem ipsum <a href="/missions/test-mission/">dolor</a> sit amet, consectetur adipiscing elit. Quisque vitae justo quis justo malesuada molestie. Cras sed tincidunt dui.</p><p>Integer imperdiet blandit neque vitae euismod. Nulla aliquet lacus nibh,  vel tincidunt urna efficitur non. In et eros vitae ex posuere maximus  quis eget urna. Suspendisse fringilla posuere velit sit amet posuere.  Morbi malesuada bibendum vehicula. Donec faucibus ut erat ut mattis.  Suspendisse ornare, quam at placerat cursus, dolor mi lacinia nunc, eget  maximus augue nulla in dolor.</p>\n'
+    },
     BlockHeadingData,
     {
       blockType: 'RichTextBlock',
       value:
         '<p>Lorem ipsum <a href="/missions/test-mission/">dolor</a> sit amet, consectetur adipiscing elit. Quisque vitae justo quis justo malesuada molestie. Cras sed tincidunt dui.</p><p>Integer imperdiet blandit neque vitae euismod. Nulla aliquet lacus nibh,  vel tincidunt urna efficitur non. In et eros vitae ex posuere maximus  quis eget urna. Suspendisse fringilla posuere velit sit amet posuere.  Morbi malesuada bibendum vehicula. Donec faucibus ut erat ut mattis.  Suspendisse ornare, quam at placerat cursus, dolor mi lacinia nunc, eget  maximus augue nulla in dolor.</p>\n'
     },
-    BlockImageComparisonData,
+    BlockImageData,
     BlockHeadingData,
     {
       blockType: 'RichTextBlock',
       value:
         '<p>Lorem ipsum <a href="/missions/test-mission/">dolor</a> sit amet, consectetur adipiscing elit. Quisque vitae justo quis justo malesuada molestie. Cras sed tincidunt dui.</p><p>Integer imperdiet blandit neque vitae euismod. Nulla aliquet lacus nibh,  vel tincidunt urna efficitur non. In et eros vitae ex posuere maximus  quis eget urna. Suspendisse fringilla posuere velit sit amet posuere.  Morbi malesuada bibendum vehicula. Donec faucibus ut erat ut mattis.  Suspendisse ornare, quam at placerat cursus, dolor mi lacinia nunc, eget  maximus augue nulla in dolor.</p>\n'
     },
-    BlockInlineImageData.block,
-    BlockIframeEmbedData
+    BlockInlineImageData.block
   ]
 }
 export const BlockStreamfieldData = {

--- a/packages/vue/src/components/BlockStreamfield/BlockStreamfield.vue
+++ b/packages/vue/src/components/BlockStreamfield/BlockStreamfield.vue
@@ -12,7 +12,7 @@
         class="mb-5"
       >
         <BlockHeading
-          :data="block"
+          :data="block as BlockHeadingObject"
           :index="index"
           generate-id
         />
@@ -216,7 +216,7 @@ import type { StreamfieldBlockData } from '../../interfaces'
 import LayoutHelper from './../LayoutHelper/LayoutHelper.vue'
 import BlockCardGrid from './../BlockCardGrid/BlockCardGrid.vue'
 import BlockCta from './../BlockCta/BlockCta.vue'
-import BlockHeading from './../BlockHeading/BlockHeading.vue'
+import BlockHeading, { BlockHeadingObject } from './../BlockHeading/BlockHeading.vue'
 import BlockImage from './../BlockImage/BlockImage.vue'
 import BlockImageCarousel from './../BlockImageCarousel/BlockImageCarousel.vue'
 import BlockImageComparison from './../BlockImageComparison/BlockImageComparison.vue'
@@ -239,7 +239,7 @@ import BlockVideoEmbed, {
 } from './../BlockVideoEmbed/BlockVideoEmbed.vue'
 import BlockAnchor from './../BlockAnchor/BlockAnchor.vue'
 interface Variants {
-  [name: string]: string
+  [key: string]: string
 }
 
 export const variants: Variants = {

--- a/packages/vue/src/components/BlockStreamfield/BlockStreamfield.vue
+++ b/packages/vue/src/components/BlockStreamfield/BlockStreamfield.vue
@@ -212,9 +212,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import type { PropType } from 'vue'
-import type { BlockData, ImageObject } from '../../interfaces'
-import type { BlockData as VideoBlockEmbedData } from './../BlockVideoEmbed/BlockVideoEmbed.vue'
-import type { BlockQuoteAttributes } from './../BlockQuote/BlockQuote.vue'
+import type { StreamfieldBlockData } from '../../interfaces'
 import LayoutHelper from './../LayoutHelper/LayoutHelper.vue'
 import BlockCardGrid from './../BlockCardGrid/BlockCardGrid.vue'
 import BlockCta from './../BlockCta/BlockCta.vue'
@@ -226,7 +224,7 @@ import BlockImageGallery from './../BlockImageGallery/BlockImageGallery.vue'
 import BlockInlineImage from './../BlockInlineImage/BlockInlineImage.vue'
 import BlockKeyPoints from './../BlockKeyPoints/BlockKeyPoints.vue'
 import BlockListCards from './../BlockListCards/BlockListCards.vue'
-import BlockQuote from './../BlockQuote/BlockQuote.vue'
+import BlockQuote, { type BlockQuoteAttributes } from './../BlockQuote/BlockQuote.vue'
 import BlockRelatedLinks, {
   type BlockRelatedLinksObject
 } from './../BlockRelatedLinks/BlockRelatedLinks.vue'
@@ -236,7 +234,9 @@ import BlockText from './../BlockText/BlockText.vue'
 import BlockTwitterEmbed from './../BlockTwitterEmbed/BlockTwitterEmbed.vue'
 import BlockIframeEmbed from './../BlockIframeEmbed/BlockIframeEmbed.vue'
 import BlockVideo from './../BlockVideo/BlockVideo.vue'
-import BlockVideoEmbed from './../BlockVideoEmbed/BlockVideoEmbed.vue'
+import BlockVideoEmbed, {
+  type BlockData as VideoBlockEmbedData
+} from './../BlockVideoEmbed/BlockVideoEmbed.vue'
 import BlockAnchor from './../BlockAnchor/BlockAnchor.vue'
 interface Variants {
   [name: string]: string
@@ -245,24 +245,6 @@ interface Variants {
 export const variants: Variants = {
   default: '',
   fluid: '-fluid'
-}
-
-export interface StreamfieldBlockData extends BlockData {
-  id: string
-  fullBleed: boolean
-  heading: string
-  galleryTitle: string
-  galleryDescription: string
-  coverImage: ImageObject
-  gallerySlides: ImageObject[]
-  blocks: object[]
-  value: string
-  customLabel: string
-  introduction: string
-  teaserPage: object | string[]
-  image: ImageObject
-  buttonText: string
-  fullWidthImage: boolean
 }
 
 export default defineComponent({

--- a/packages/vue/src/components/BlockText/BlockText.vue
+++ b/packages/vue/src/components/BlockText/BlockText.vue
@@ -9,7 +9,7 @@
 import { defineComponent } from 'vue'
 
 interface Variants {
-  [name: string]: string
+  [key: string]: string
 }
 
 export const variants: Variants = {

--- a/packages/vue/src/components/HeroMedia/HeroMedia.vue
+++ b/packages/vue/src/components/HeroMedia/HeroMedia.vue
@@ -154,7 +154,7 @@ export default defineComponent({
       if (this.theImageData) {
         if (this.themeStore.isEdu) {
           // For EDU, only show the caption area if there is a caption
-          return this.theImageCaption
+          return this.theImageCaption ? this.theImageCaption : false
         } else {
           // For others, show the caption area if there is also a credit or detail URL
           return this.theImageCaption || this.image?.credit || this.image?.detailUrl

--- a/packages/vue/src/components/HeroMedia/HeroMedia.vue
+++ b/packages/vue/src/components/HeroMedia/HeroMedia.vue
@@ -53,6 +53,8 @@
 </template>
 <script lang="ts">
 import { defineComponent } from 'vue'
+import { mapStores } from 'pinia'
+import { useThemeStore } from '../../store/theme'
 import MixinVideoBg from './../MixinVideoBg/MixinVideoBg.vue'
 import BaseImageCaption from './../BaseImageCaption/BaseImageCaption.vue'
 import IconInfo from './../Icons/IconInfo.vue'
@@ -105,6 +107,7 @@ export default defineComponent({
     }
   },
   computed: {
+    ...mapStores(useThemeStore),
     theImageCaption(): string | undefined {
       if (this.image && this.caption && this.caption.length > 2 && this.displayCaption) {
         return this.caption
@@ -149,7 +152,13 @@ export default defineComponent({
     },
     hasCaptionArea(): string | boolean {
       if (this.theImageData) {
-        return this.theImageCaption || this.image?.credit || this.image?.detailUrl
+        if (this.themeStore.isEdu) {
+          // For EDU, only show the caption area if there is a caption
+          return this.theImageCaption
+        } else {
+          // For others, show the caption area if there is also a credit or detail URL
+          return this.theImageCaption || this.image?.credit || this.image?.detailUrl
+        }
       } else if (this.customCaption) {
         return true
       }

--- a/packages/vue/src/components/LayoutHelper/LayoutHelper.vue
+++ b/packages/vue/src/components/LayoutHelper/LayoutHelper.vue
@@ -2,7 +2,7 @@
 import { defineComponent } from 'vue'
 
 interface Indents {
-  [name: string]: string
+  [key: string]: string
 }
 
 export const indents: Indents = {

--- a/packages/vue/src/components/MetaPanel/MetaPanel.stories.js
+++ b/packages/vue/src/components/MetaPanel/MetaPanel.stories.js
@@ -1,0 +1,110 @@
+import MetaPanel from './MetaPanel.vue'
+
+export default {
+  title: 'Components/Utilities/MetaPanel',
+  component: MetaPanel,
+  tags: ['!autodocs'],
+  decorators: [
+    () => ({
+      template: `<div><div class="h-40 w-full max-w-screen-3xl mx-auto bg-gray-dark"><p class="text-white">Dark background for demo purposes only and not part of the component.</p></div><div id="storyDecorator"><story/></div></div>`
+    })
+  ],
+  parameters: {
+    layout: 'fullscreen'
+  },
+  argTypes: {
+    theme: {
+      type: { name: 'string', required: false },
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'stars']
+    }
+  }
+}
+
+// stories
+export const BaseStory = {
+  name: 'MetaPanel',
+  args: {
+    dropdown: 'View Standards',
+    primarySubject: 'Math',
+    additionalSubjects: ['Science'],
+    time: '30mins - hr',
+    gradeLevels: [
+      { gradeLevel: 'All Ages' },
+      { gradeLevel: 'K' },
+      { gradeLevel: '1' },
+      { gradeLevel: '2' },
+      { gradeLevel: '5' },
+      { gradeLevel: '6' },
+      { gradeLevel: '7' },
+      { gradeLevel: '8' }
+    ],
+    standards: [
+      {
+        standard: {
+          code: 'CCRA.R.1',
+          definition:
+            'Read closely to determine what the text says explicitly and to make logical inferences from it; cite specific textual evidence when writing or speaking to support conclusions drawn from the text.',
+          domain: {
+            domain: 'College and Career Readiness Anchor Standards for Reading'
+          },
+          type: 'ccss_english_language_arts'
+        }
+      },
+      {
+        standard: {
+          code: 'RL.3.2',
+          definition:
+            'Recount stories, including fables, folktales, and myths from diverse cultures; determine the central message, lesson, or moral and explain how it is conveyed through key details in the text.',
+          domain: {
+            domain: 'Reading Standards for Literature'
+          },
+          type: 'ccss_english_language_arts'
+        }
+      },
+      {
+        standard: {
+          code: 'RL.1.5',
+          definition:
+            'Explain major differences between books that tell stories and books that give information, drawing on a wide reading of a range of text types.',
+          domain: {
+            domain: 'Reading Standards for Literature'
+          },
+          type: 'ccss_english_language_arts'
+        }
+      },
+      {
+        standard: {
+          code: 'K.CC.A',
+          definition: 'Know number names and the count sequence.',
+          domain: {
+            domain: 'Counting and Cardinality'
+          },
+          type: 'ccss_maths'
+        }
+      },
+      {
+        standard: {
+          code: 'K.CC.A.3',
+          definition:
+            'Write numbers from 0 to 20. Represent a number of objects with a written numeral 0-20 (with 0 representing a count of no objects).',
+          domain: {
+            domain: 'Counting and Cardinality'
+          },
+          type: 'ccss_maths'
+        }
+      },
+      {
+        standard: {
+          code: 'K-PS2-1',
+          definition:
+            'Plan and conduct an investigation to compare the effects of different strengths or different directions of pushes and pulls on the motion of an object.',
+          domain: {
+            domain: 'Physical Sciences'
+          },
+          type: 'ngss'
+        }
+      }
+    ]
+  }
+}

--- a/packages/vue/src/components/MetaPanel/MetaPanel.stories.js
+++ b/packages/vue/src/components/MetaPanel/MetaPanel.stories.js
@@ -6,7 +6,7 @@ export default {
   tags: ['!autodocs'],
   decorators: [
     () => ({
-      template: `<div><div class="h-40 w-full max-w-screen-3xl mx-auto bg-gray-dark"><p class="text-white">Dark background for demo purposes only and not part of the component.</p></div><div id="storyDecorator"><story/></div></div>`
+      template: `<div><div class="h-40 w-full max-w-screen-3xl mx-auto bg-gray-dark"><p class="text-white">Dark background for demo purposes only and not part of the component.</p></div><div id="storyDecorator"><story/></div><div class="h-40 w-full max-w-screen-3xl mx-auto bg-gray-dark"><p class="text-white">Dark background for demo purposes only and not part of the component.</p></div></div>`
     })
   ],
   parameters: {
@@ -25,7 +25,9 @@ export default {
 export const BaseStory = {
   name: 'MetaPanel',
   args: {
-    dropdown: 'View Standards',
+    negativeTop: true,
+    negativeBottom: true,
+    button: 'View Standards',
     primarySubject: 'Math',
     additionalSubjects: ['Science'],
     time: '30mins - hr',

--- a/packages/vue/src/components/MetaPanel/MetaPanel.vue
+++ b/packages/vue/src/components/MetaPanel/MetaPanel.vue
@@ -1,0 +1,217 @@
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue'
+import { MetaPanelTheme } from './../../interfaces'
+import MetaPanelAccordion from './../MetaPanelAccordion/MetaPanelAccordion.vue'
+import MetaPanelItems from './../MetaPanelItems/MetaPanelItems.vue'
+import IconMinus from './../Icons/IconMinus.vue'
+import IconPlus from './../Icons/IconPlus.vue'
+import BaseButton from './../BaseButton/BaseButton.vue'
+
+interface MetaPanelProps {
+  dropdown?: string
+  theme?: MetaPanelTheme
+  primarySubject?: string
+  additionalSubjects?: string[]
+  gradeLevels?: any
+  time?: string
+  standards?: any[]
+}
+
+// define props
+const props = withDefaults(defineProps<MetaPanelProps>(), {
+  dropdown: undefined,
+  theme: 'primary',
+  primarySubject: undefined,
+  additionalSubjects: undefined,
+  gradeLevels: undefined,
+  time: undefined,
+  standards: undefined
+})
+const { dropdown, theme, primarySubject, additionalSubjects, gradeLevels, time, standards } =
+  reactive(props)
+
+const metaPanelOpen = ref(false)
+
+const handleMetaPanel = () => {
+  metaPanelOpen.value = !metaPanelOpen.value
+  console.log('handle meta panel')
+}
+
+const buttonText = computed(() => {
+  let text = dropdown
+  if (text) {
+    if (metaPanelOpen.value) {
+      text = text.replace('View', 'Hide')
+    }
+  }
+  return text
+})
+
+const backgroundClass = computed(() => {
+  let classes = 'bg-gray-light'
+  if (theme === 'stars') {
+    classes = 'bg-primary bg-stars bg-auto lg:bg-cover'
+  }
+  return classes
+})
+const headingClass = computed(() => {
+  let classes = 'text-primary'
+  if (theme === 'secondary') {
+    classes = 'text-secondary'
+  }
+  return classes
+})
+const borderClass = computed(() => {
+  let classes = 'border-t border-gray-light-mid'
+  if (theme === 'stars') {
+    classes = ''
+  }
+  return classes
+})
+
+const sortedStandards = computed(() => {
+  if (standards) {
+    const sorted = standards.reduce((acc, item) => {
+      const type = item.standard.type
+      // Initialize array for type if it doesn't exist
+      if (!acc[type]) {
+        acc[type] = []
+      }
+      // Add item to the appropriate type array
+      acc[type].push(item)
+      return acc
+    }, {})
+    return sorted
+  }
+  return undefined
+})
+
+const standardsEla = computed(() => {
+  return sortedStandards.value ? sortedStandards.value['ccss_english_language_arts'] : undefined
+})
+const standardsMath = computed(() => {
+  return sortedStandards.value ? sortedStandards.value['ccss_math'] : undefined
+})
+const standardsNgss = computed(() => {
+  return sortedStandards.value ? sortedStandards.value['ngss'] : undefined
+})
+const standardsIste = computed(() => {
+  return sortedStandards.value ? sortedStandards.value['iste'] : undefined
+})
+</script>
+
+<template>
+  <section
+    aria-label="Metadata"
+    class="MetaPanel -mt-14 z-20 overflow-hidden"
+  >
+    <div class="MixedBleedGrid pl-4 lg:pl-0">
+      <div
+        class="col-start-indent-col-2 col-end-bleed"
+        :class="backgroundClass"
+      >
+        <div class="MetaPanel-heading lg:grid grid-cols-10 col-end-container container">
+          <div class="col-start-1 col-end-8 xl:col-end-7 pl-4 lg:pl-10 pr-2 py-6 lg:py-10">
+            <MetaPanelItems
+              :theme="theme"
+              :primary-subject="primarySubject"
+              :additional-subjects="additionalSubjects"
+              :grade-levels="gradeLevels"
+              :time="time"
+            />
+          </div>
+          <div
+            v-if="dropdown"
+            class="ThemeVariantLight col-start-8 col-end-11 pl-4 lg:pl-10 pr-5 pt-4 pb-6 lg:py-10 lg:text-right"
+          >
+            <BaseButton
+              variant="secondary"
+              class="MetaPanel-button"
+              :aria-expanded="metaPanelOpen"
+              compact
+              @click="handleMetaPanel"
+            >
+              {{ buttonText }}
+              <template #icon>
+                <IconPlus
+                  v-if="!metaPanelOpen"
+                  class="text-xs ml-2"
+                />
+                <IconMinus
+                  v-else
+                  class="text-xs ml-2"
+                />
+              </template>
+            </BaseButton>
+          </div>
+        </div>
+        <div
+          v-if="dropdown"
+          v-show="metaPanelOpen"
+          class="MetaPanel-panel bg-gray-light pb-3 lg:pb-6"
+        >
+          <div class="container px-8 lg:px-[5.8rem]">
+            <div
+              class="pt-6 lg:pt-7"
+              :class="borderClass"
+            >
+              <div
+                class="text-subtitle mb-5"
+                :class="headingClass"
+              >
+                Standards
+                <span class="sr-only">.</span>
+              </div>
+              <div class="w-full lg:grid grid-cols-2 lg:gap-6 xl:gap-10">
+                <div v-if="standardsEla">
+                  <div class="text-base font-semibold text-gray-dark mb-4">
+                    English Language Arts Standards
+                  </div>
+                  <span class="sr-only">.</span>
+                  <MetaPanelAccordion
+                    :standards="standardsEla"
+                    class="mb-6"
+                  />
+                </div>
+                <div v-if="standardsMath">
+                  <div class="text-base font-semibold text-gray-dark mb-4">
+                    Common Core State Standards For Math
+                  </div>
+                  <span class="sr-only">.</span>
+                  <MetaPanelAccordion
+                    :standards="standardsMath"
+                    class="mb-6"
+                  />
+                </div>
+                <div v-if="standardsNgss">
+                  <div class="text-base font-semibold text-gray-dark mb-4">
+                    Next Generation Science Standards
+                  </div>
+                  <span class="sr-only">.</span>
+                  <MetaPanelAccordion
+                    :standards="standardsNgss"
+                    class="mb-6"
+                  />
+                </div>
+                <div v-if="standardsIste">
+                  <div class="text-base font-semibold text-gray-dark mb-4">
+                    Technology Standards (ISTE)
+                  </div>
+                  <span class="sr-only">.</span>
+                  <MetaPanelAccordion :standards="standardsIste" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+<style lang="scss">
+.MetaPanel {
+  .MetaPanel-button {
+    @apply border-[1px] font-primary normal-case tracking-normal font-bold text-lg py-2 bg-white;
+  }
+}
+</style>

--- a/packages/vue/src/components/MetaPanel/MetaPanel.vue
+++ b/packages/vue/src/components/MetaPanel/MetaPanel.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue'
-import { MetaPanelTheme } from './../../interfaces'
+import {
+  MetaPanelTheme,
+  EduResourcesGradeLevel,
+  EduStandard,
+  EduResourcesSubject,
+  EduResourcesTime
+} from './../../interfaces'
 import MetaPanelAccordion from './../MetaPanelAccordion/MetaPanelAccordion.vue'
 import MetaPanelItems from './../MetaPanelItems/MetaPanelItems.vue'
 import IconMinus from './../Icons/IconMinus.vue'
@@ -10,11 +16,11 @@ import BaseButton from './../BaseButton/BaseButton.vue'
 interface MetaPanelProps {
   button?: string
   theme?: MetaPanelTheme
-  primarySubject?: string
-  additionalSubjects?: string[]
-  gradeLevels?: any
-  time?: string
-  standards?: any[]
+  primarySubject?: EduResourcesSubject
+  additionalSubjects?: EduResourcesSubject[]
+  gradeLevels?: EduResourcesGradeLevel[]
+  time?: EduResourcesTime
+  standards?: EduStandard[]
   negativeTop?: boolean
   negativeBottom?: boolean
 }
@@ -38,7 +44,6 @@ const metaPanelOpen = ref(false)
 
 const handleMetaPanel = () => {
   metaPanelOpen.value = !metaPanelOpen.value
-  console.log('handle meta panel')
 }
 
 const buttonText = computed(() => {

--- a/packages/vue/src/components/MetaPanel/MetaPanel.vue
+++ b/packages/vue/src/components/MetaPanel/MetaPanel.vue
@@ -120,50 +120,54 @@ const standardsIste = computed(() => {
   >
     <div class="MixedBleedGrid pl-4 lg:pl-0">
       <div
-        class="col-start-indent-col-2 col-end-bleed"
+        class="col-start-indent-col-2 col-end-bleed lg:grid grid-cols-subgrid"
         :class="backgroundClass"
       >
-        <div class="MetaPanel-heading lg:grid grid-cols-10 col-end-container container">
-          <div class="col-start-1 col-end-8 xl:col-end-7 pl-4 lg:pl-10 pr-2 py-6 lg:py-10">
-            <MetaPanelItems
-              :theme="theme"
-              :primary-subject="primarySubject"
-              :additional-subjects="additionalSubjects"
-              :grade-levels="gradeLevels"
-              :time="time"
-            />
-          </div>
-          <div
-            v-if="button"
-            class="ThemeVariantLight col-start-8 col-end-11 pl-4 lg:pl-10 pr-5 pt-4 pb-6 lg:py-10 lg:text-right"
-          >
-            <BaseButton
-              variant="secondary"
-              class="MetaPanel-button"
-              :aria-expanded="metaPanelOpen"
-              compact
-              @click="handleMetaPanel"
+        <div class="is-this-needed col-start-indent-col-2 col-end-container">
+          <div class="MetaPanel-heading lg:grid grid-cols-12 col-end-container container">
+            <div class="col-start-1 col-end-10 xl:col-end-9 pl-4 lg:pl-10 pr-2 py-6 lg:py-10">
+              <MetaPanelItems
+                :theme="theme"
+                :primary-subject="primarySubject"
+                :additional-subjects="additionalSubjects"
+                :grade-levels="gradeLevels"
+                :time="time"
+              />
+            </div>
+            <div
+              v-if="button"
+              class="ThemeVariantLight col-start-10 col-end-13 pl-4 pt-4 pb-6 lg:py-10 lg:text-right"
             >
-              {{ buttonText }}
-              <template #icon>
-                <IconPlus
-                  v-if="!metaPanelOpen"
-                  class="text-xs ml-2"
-                />
-                <IconMinus
-                  v-else
-                  class="text-xs ml-2"
-                />
-              </template>
-            </BaseButton>
+              <BaseButton
+                variant="secondary"
+                class="MetaPanel-button"
+                :aria-expanded="metaPanelOpen"
+                compact
+                @click="handleMetaPanel"
+              >
+                {{ buttonText }}
+                <template #icon>
+                  <IconPlus
+                    v-if="!metaPanelOpen"
+                    class="text-xs ml-2"
+                  />
+                  <IconMinus
+                    v-else
+                    class="text-xs ml-2"
+                  />
+                </template>
+              </BaseButton>
+            </div>
           </div>
         </div>
         <div
           v-if="standards"
           v-show="metaPanelOpen"
-          class="MetaPanel-panel bg-gray-light pb-3 lg:pb-6"
+          class="MetaPanel-panel col-start-indent-col-2 col-end-bleed lg:grid grid-cols-subgrid bg-gray-light pb-3 lg:pb-6"
         >
-          <div class="container px-8 lg:px-[5.8rem]">
+          <div
+            class="container col-start-indent-col-2 col-end-container px-8 lg:px-[3rem] xl:px-[5.8rem]"
+          >
             <div
               class="pt-6 lg:pt-7"
               :class="borderClass"

--- a/packages/vue/src/components/MetaPanel/MetaPanel.vue
+++ b/packages/vue/src/components/MetaPanel/MetaPanel.vue
@@ -120,10 +120,10 @@ const standardsIste = computed(() => {
   >
     <div class="MixedBleedGrid pl-4 lg:pl-0">
       <div
-        class="col-start-indent-col-2 col-end-bleed lg:grid grid-cols-subgrid"
+        class="col-start-container lg:col-start-indent-col-2 col-end-bleed lg:grid grid-cols-subgrid"
         :class="backgroundClass"
       >
-        <div class="is-this-needed col-start-indent-col-2 col-end-container">
+        <div class="is-this-needed col-start-container lg:col-start-indent-col-2 col-end-container">
           <div class="MetaPanel-heading lg:grid grid-cols-12 col-end-container container">
             <div class="col-start-1 col-end-10 xl:col-end-9 pl-4 lg:pl-10 pr-2 py-6 lg:py-10">
               <MetaPanelItems
@@ -163,10 +163,10 @@ const standardsIste = computed(() => {
         <div
           v-if="standards"
           v-show="metaPanelOpen"
-          class="MetaPanel-panel col-start-indent-col-2 col-end-bleed lg:grid grid-cols-subgrid bg-gray-light pb-3 lg:pb-6"
+          class="MetaPanel-panel col-start-container lg:col-start-indent-col-2 col-end-bleed lg:grid grid-cols-subgrid bg-gray-light pb-3 lg:pb-6"
         >
           <div
-            class="container col-start-indent-col-2 col-end-container px-8 lg:px-[3rem] xl:px-[5.8rem]"
+            class="container col-start-container lg:col-start-indent-col-2 col-end-container px-8 lg:px-[3rem] xl:px-[5.8rem]"
           >
             <div
               class="pt-6 lg:pt-7"

--- a/packages/vue/src/components/MetaPanel/MetaPanel.vue
+++ b/packages/vue/src/components/MetaPanel/MetaPanel.vue
@@ -8,26 +8,30 @@ import IconPlus from './../Icons/IconPlus.vue'
 import BaseButton from './../BaseButton/BaseButton.vue'
 
 interface MetaPanelProps {
-  dropdown?: string
+  button?: string
   theme?: MetaPanelTheme
   primarySubject?: string
   additionalSubjects?: string[]
   gradeLevels?: any
   time?: string
   standards?: any[]
+  negativeTop?: boolean
+  negativeBottom?: boolean
 }
 
 // define props
 const props = withDefaults(defineProps<MetaPanelProps>(), {
-  dropdown: undefined,
+  button: undefined,
   theme: 'primary',
   primarySubject: undefined,
   additionalSubjects: undefined,
   gradeLevels: undefined,
   time: undefined,
-  standards: undefined
+  standards: undefined,
+  negativeTop: false,
+  negativeBottom: false
 })
-const { dropdown, theme, primarySubject, additionalSubjects, gradeLevels, time, standards } =
+const { button, theme, primarySubject, additionalSubjects, gradeLevels, time, standards } =
   reactive(props)
 
 const metaPanelOpen = ref(false)
@@ -38,7 +42,7 @@ const handleMetaPanel = () => {
 }
 
 const buttonText = computed(() => {
-  let text = dropdown
+  let text = button
   if (text) {
     if (metaPanelOpen.value) {
       text = text.replace('View', 'Hide')
@@ -103,7 +107,11 @@ const standardsIste = computed(() => {
 <template>
   <section
     aria-label="Metadata"
-    class="MetaPanel -mt-14 z-20 overflow-hidden"
+    class="MetaPanel z-20 relative overflow-hidden"
+    :class="{
+      '-mt-14': negativeTop,
+      '-mb-14': negativeBottom
+    }"
   >
     <div class="MixedBleedGrid pl-4 lg:pl-0">
       <div
@@ -121,7 +129,7 @@ const standardsIste = computed(() => {
             />
           </div>
           <div
-            v-if="dropdown"
+            v-if="button"
             class="ThemeVariantLight col-start-8 col-end-11 pl-4 lg:pl-10 pr-5 pt-4 pb-6 lg:py-10 lg:text-right"
           >
             <BaseButton
@@ -146,7 +154,7 @@ const standardsIste = computed(() => {
           </div>
         </div>
         <div
-          v-if="dropdown"
+          v-if="standards"
           v-show="metaPanelOpen"
           class="MetaPanel-panel bg-gray-light pb-3 lg:pb-6"
         >

--- a/packages/vue/src/components/MetaPanel/MetaPanel.vue
+++ b/packages/vue/src/components/MetaPanel/MetaPanel.vue
@@ -3,7 +3,7 @@ import { computed, reactive, ref } from 'vue'
 import {
   MetaPanelTheme,
   EduResourcesGradeLevel,
-  EduStandard,
+  EduResourceStandardItem,
   EduResourcesSubject,
   EduResourcesTime
 } from './../../interfaces'
@@ -20,7 +20,7 @@ interface MetaPanelProps {
   additionalSubjects?: EduResourcesSubject[]
   gradeLevels?: EduResourcesGradeLevel[]
   time?: EduResourcesTime
-  standards?: EduStandard[]
+  standards?: EduResourceStandardItem[]
   negativeTop?: boolean
   negativeBottom?: boolean
 }
@@ -78,9 +78,12 @@ const borderClass = computed(() => {
   return classes
 })
 
-const sortedStandards = computed(() => {
+interface SortedStandards {
+  [key: string]: EduResourceStandardItem[]
+}
+const sortedStandards = computed((): SortedStandards | undefined => {
   if (standards) {
-    const sorted = standards.reduce((acc, item) => {
+    const sorted = standards.reduce<SortedStandards>((acc, item) => {
       const type = item.standard.type
       // Initialize array for type if it doesn't exist
       if (!acc[type]) {

--- a/packages/vue/src/components/MetaPanelAccordion/MetaPanelAccordion.vue
+++ b/packages/vue/src/components/MetaPanelAccordion/MetaPanelAccordion.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import { reactive } from 'vue'
-import type { EduStandard } from './../../interfaces'
+import type { AccordionItemObject, EduResourceStandardItem } from './../../interfaces'
 import BaseAccordionItem from './../BaseAccordionItem/BaseAccordionItem.vue'
-import BlockText from './../BlockText/BlockText.vue'
 
 interface MetaPanelAccordionProps {
-  standards?: EduStandard[]
+  standards?: EduResourceStandardItem[]
 }
 const props = withDefaults(defineProps<MetaPanelAccordionProps>(), {
   standards: undefined
@@ -20,7 +19,7 @@ const { standards } = reactive(props)
       :key="index"
       heading-level="h3"
       class="mb-2 bg-white"
-      :item="item.standard"
+      :item="item.standard as AccordionItemObject"
     >
       <template #heading>
         <div class="w-full text-left pr-5">

--- a/packages/vue/src/components/MetaPanelAccordion/MetaPanelAccordion.vue
+++ b/packages/vue/src/components/MetaPanelAccordion/MetaPanelAccordion.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { reactive } from 'vue'
+import type { EduStandard } from './../../interfaces'
+import BaseAccordionItem from './../BaseAccordionItem/BaseAccordionItem.vue'
+import BlockText from './../BlockText/BlockText.vue'
+
+interface MetaPanelAccordionProps {
+  standards?: EduStandard[]
+}
+const props = withDefaults(defineProps<MetaPanelAccordionProps>(), {
+  standards: undefined
+})
+const { standards } = reactive(props)
+</script>
+
+<template>
+  <div class="MetaPanelAccordion">
+    <BaseAccordionItem
+      v-for="(item, index) in standards"
+      :key="index"
+      heading-level="h3"
+      class="mb-2 bg-white"
+      :item="item.standard"
+    >
+      <template #heading>
+        <div class="w-full text-left pr-5">
+          <div class="text-sm tracking-normal text-action mb-0 can-hover:group-hover:underline">
+            {{ item.standard.domain?.domain }}
+          </div>
+          <div class="text-sm text-gray-mid-dark font-normal tracking-normal">
+            {{ item.standard.code }}
+          </div>
+        </div>
+      </template>
+      <template #panelContents>
+        <div class="pl-3 pb-3 pr-8 text-sm text-gray-dark">
+          <p>{{ item.standard.definition }}</p>
+        </div>
+      </template>
+    </BaseAccordionItem>
+  </div>
+</template>
+<style lang="scss">
+.MetaPanelAccordion {
+  .BaseAccordionItem {
+    .BaseAccordionHeader {
+      @apply bg-white;
+      > div {
+        @apply border-none;
+      }
+      button.BaseAccordion-trigger {
+        @apply py-2 px-3;
+        @apply can-hover:hover:no-underline;
+      }
+    }
+    &.-open {
+      .BaseAccordionHeader {
+        button.BaseAccordion-trigger {
+          @apply pb-0;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/packages/vue/src/components/MetaPanelItems/MetaPanelItems.stories.js
+++ b/packages/vue/src/components/MetaPanelItems/MetaPanelItems.stories.js
@@ -10,9 +10,9 @@ export default {
 export const BaseStory = {
   name: 'MetaPanelItems',
   args: {
-    primarySubject: 'Math',
-    additionalSubjects: ['Science'],
-    time: '30mins - hr',
+    primarySubject: { subject: 'Math' },
+    additionalSubjects: [{ subject: 'Science' }],
+    time: { time: '30mins - hr' },
     gradeLevels: [
       { gradeLevel: 'All Ages' },
       { gradeLevel: 'K' },

--- a/packages/vue/src/components/MetaPanelItems/MetaPanelItems.stories.js
+++ b/packages/vue/src/components/MetaPanelItems/MetaPanelItems.stories.js
@@ -1,0 +1,27 @@
+import MetaPanelItems from './MetaPanelItems.vue'
+
+export default {
+  title: 'Components/Utilities/MetaPanelItems',
+  component: MetaPanelItems,
+  tags: ['!autodocs']
+}
+
+// stories
+export const BaseStory = {
+  name: 'MetaPanelItems',
+  args: {
+    primarySubject: 'Math',
+    additionalSubjects: ['Science'],
+    time: '30mins - hr',
+    gradeLevels: [
+      { gradeLevel: 'All Ages' },
+      { gradeLevel: 'K' },
+      { gradeLevel: '1' },
+      { gradeLevel: '2' },
+      { gradeLevel: '5' },
+      { gradeLevel: '6' },
+      { gradeLevel: '7' },
+      { gradeLevel: '8' }
+    ]
+  }
+}

--- a/packages/vue/src/components/MetaPanelItems/MetaPanelItems.vue
+++ b/packages/vue/src/components/MetaPanelItems/MetaPanelItems.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { computed, reactive } from 'vue'
+import { rangeifyGrades } from './../../utils/rangeifyGrades'
+import { MetaPanelTheme } from './../../interfaces'
+import IconSubject from './../Icons/IconSubject.vue'
+import IconProfile from './../Icons/IconProfile.vue'
+import IconTime from './../Icons/IconTime.vue'
+
+interface MetaPanelProps {
+  theme?: MetaPanelTheme
+  primarySubject: string
+  additionalSubjects?: string[]
+  gradeLevels?: any
+  time?: string
+}
+
+// define props
+const props = withDefaults(defineProps<MetaPanelProps>(), {
+  theme: 'primary',
+  primarySubject: undefined,
+  additionalSubjects: undefined,
+  gradeLevels: undefined,
+  time: undefined
+})
+
+const { theme, primarySubject, additionalSubjects, gradeLevels, time } = reactive(props)
+
+const audience = computed(() => {
+  return gradeLevels ? rangeifyGrades(gradeLevels) : undefined
+})
+
+const subjects = computed(() => {
+  let combinedArray = [primarySubject]
+  let output = undefined
+  if (additionalSubjects) {
+    combinedArray = combinedArray.concat(additionalSubjects)
+  }
+  output = combinedArray.join(', ')
+  return output
+})
+
+const iconColor = computed(() => {
+  let classes = 'text-primary'
+  if (theme === 'secondary') {
+    classes = 'text-secondary'
+  } else if (theme === 'stars') {
+    classes = 'text-white'
+  }
+  return classes
+})
+const headingColor = computed(() => {
+  let classes = 'text-primary'
+  if (theme === 'secondary') {
+    classes = 'text-secondary'
+  } else if (theme === 'stars') {
+    classes = 'text-white opacity-60'
+  }
+
+  return classes
+})
+const textColor = computed(() => {
+  let classes = 'text-gray-dark'
+  if (theme === 'stars') {
+    classes = 'text-white'
+  }
+  return classes
+})
+const themeVariant = computed(() => {
+  let variant = 'ThemeVariantGray'
+  if (theme === 'stars') {
+    variant = 'ThemeVariantDark'
+  }
+  return variant
+})
+</script>
+
+<template>
+  <div
+    class="MetaPanelItems md:flex gap-10"
+    :class="{ 'justify-between': subjects && audience && time }"
+  >
+    <div
+      v-if="subjects"
+      class="MetaPanelItem"
+    >
+      <div
+        class="MetaPanelItem-icon"
+        :class="iconColor"
+      >
+        <IconSubject class="text-[2em] md:text-[2.4em]" />
+      </div>
+      <div>
+        <div
+          class="MetaPanelItem-heading"
+          :class="`${themeVariant} ${headingColor}`"
+        >
+          Subjects
+          <span class="sr-only">.</span>
+        </div>
+        <div
+          class="MetaPanelItem-content"
+          :class="textColor"
+        >
+          {{ subjects }}
+        </div>
+      </div>
+    </div>
+    <div
+      v-if="audience"
+      class="MetaPanelItem"
+    >
+      <div
+        class="MetaPanelItem-icon"
+        :class="iconColor"
+      >
+        <IconProfile class="text-[2.1em] md:text-[2.5em] mt-1 md:mt-0" />
+      </div>
+      <div>
+        <div
+          class="MetaPanelItem-heading"
+          :class="`${themeVariant} ${headingColor}`"
+        >
+          Grade Levels
+          <span class="sr-only">.</span>
+        </div>
+        <div
+          class="MetaPanelItem-content"
+          :class="textColor"
+        >
+          {{ audience }}
+        </div>
+      </div>
+    </div>
+    <div
+      v-if="time"
+      class="MetaPanelItem"
+    >
+      <div
+        class="MetaPanelItem-icon"
+        :class="iconColor"
+      >
+        <IconTime class="text-[1.6em] md:text-[2em] ml-1 mt-1" />
+      </div>
+      <div>
+        <div
+          class="MetaPanelItem-heading"
+          :class="`${themeVariant} ${headingColor}`"
+        >
+          Time Required
+          <span class="sr-only">.</span>
+        </div>
+        <div
+          class="MetaPanelItem-content"
+          :class="textColor"
+        >
+          {{ time }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<style lang="scss">
+.MetaPanelItems {
+  .MetaPanelItem {
+    @apply flex w-full items-start mb-4 md:mb-0 w-auto;
+    &:last-of-type {
+      @apply mb-0;
+    }
+    .MetaPanelItem-icon {
+      @apply mr-1 w-10 md:w-12;
+    }
+    .MetaPanelItem-heading {
+      @apply text-subtitle text-base md:mb-[.2em] whitespace-nowrap;
+    }
+    .MetaPanelItem-content {
+      @apply font-primary font-bold lg:text-xl;
+    }
+  }
+}
+</style>

--- a/packages/vue/src/components/MetaPanelItems/MetaPanelItems.vue
+++ b/packages/vue/src/components/MetaPanelItems/MetaPanelItems.vue
@@ -1,17 +1,22 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue'
 import { rangeifyGrades } from './../../utils/rangeifyGrades'
-import { MetaPanelTheme } from './../../interfaces'
+import {
+  MetaPanelTheme,
+  EduResourcesSubject,
+  EduResourcesGradeLevel,
+  EduResourcesTime
+} from './../../interfaces'
 import IconSubject from './../Icons/IconSubject.vue'
 import IconProfile from './../Icons/IconProfile.vue'
 import IconTime from './../Icons/IconTime.vue'
 
 interface MetaPanelProps {
   theme?: MetaPanelTheme
-  primarySubject: string
-  additionalSubjects?: string[]
-  gradeLevels?: any
-  time?: string
+  primarySubject: EduResourcesSubject
+  additionalSubjects?: EduResourcesSubject[]
+  gradeLevels?: EduResourcesGradeLevel[]
+  time?: EduResourcesTime
 }
 
 // define props
@@ -30,10 +35,11 @@ const audience = computed(() => {
 })
 
 const subjects = computed(() => {
-  let combinedArray = [primarySubject]
+  let combinedArray = [primarySubject.subject]
   let output = undefined
   if (additionalSubjects) {
-    combinedArray = combinedArray.concat(additionalSubjects)
+    const filteredArray = additionalSubjects.map((item) => item.subject)
+    combinedArray = combinedArray.concat(filteredArray)
   }
   output = combinedArray.join(', ')
   return output
@@ -132,7 +138,7 @@ const themeVariant = computed(() => {
       </div>
     </div>
     <div
-      v-if="time"
+      v-if="time?.time"
       class="MetaPanelItem"
     >
       <div
@@ -153,7 +159,7 @@ const themeVariant = computed(() => {
           class="MetaPanelItem-content"
           :class="textColor"
         >
-          {{ time }}
+          {{ time.time }}
         </div>
       </div>
     </div>

--- a/packages/vue/src/components/MetadataEduResource/MetadataEduResource.stories.js
+++ b/packages/vue/src/components/MetadataEduResource/MetadataEduResource.stories.js
@@ -7,10 +7,8 @@ export default {
   argTypes: {
     variant: {
       type: { name: 'string', required: false },
-      control: {
-        type: 'select',
-        options: ['primary', 'secondary']
-      }
+      control: { type: 'select' },
+      options: ['primary', 'secondary']
     }
   },
   excludeStories: /.*Data$/

--- a/packages/vue/src/components/MixinCarousel/MixinCarousel.vue
+++ b/packages/vue/src/components/MixinCarousel/MixinCarousel.vue
@@ -113,7 +113,7 @@ const MixinCarouselOptions = swiperOptions.MixinCarousel
 Swiper.use([Navigation, A11y])
 
 interface Variants {
-  [name: string]: string
+  [key: string]: string
 }
 
 export const variants: Variants = {
@@ -122,7 +122,7 @@ export const variants: Variants = {
 }
 
 interface Indents {
-  [name: string]: string
+  [key: string]: string
 }
 
 export const indents: Indents = {

--- a/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
+++ b/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
@@ -205,10 +205,12 @@ watch(
     }
     &.-is-sticky-offset {
       &.-force-show-jump-menu-offset {
-        @apply opacity-100 transition-none #{!important};
+        @apply opacity-100  #{!important};
+        @apply transition-none #{!important};
       }
       &.-force-show-hide-menu-offset {
-        @apply opacity-0 transition-none #{!important};
+        @apply opacity-0 #{!important};
+        @apply transition-none #{!important};
       }
     }
   }

--- a/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
+++ b/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
@@ -1,7 +1,6 @@
 <template>
   <NavSecondary
     v-if="enabled"
-    id="JumpMenuTop"
     ref="NavJumpMenuRef"
     class="NavJumpMenu -hide-until-threshold"
     :invert="invert"
@@ -95,11 +94,11 @@ const theBreadcrumbs = computed(() => {
   const rootItem = props.title
     ? {
         title: props.title,
-        path: '#JumpMenuTop'
+        path: '#siteTop'
       }
     : {
         title: 'Back to top',
-        path: '#JumpMenuTop'
+        path: '#siteTop'
       }
   const jumpMenu: BreadcrumbPathObject = {
     title: 'Jump to…',

--- a/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
+++ b/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
@@ -63,9 +63,6 @@ const props = withDefaults(defineProps<NavJumpMenuProps>(), {
 })
 
 const NavJumpMenuRef = ref()
-const observer = ref()
-const observerOffset = ref()
-const observeMe = ref()
 
 const theJumpLinks = computed(() => {
   if (props.jumpLinks) {
@@ -115,65 +112,11 @@ const theBreadcrumbs = computed(() => {
   return breadcrumb as BreadcrumbPathObject[] | undefined
 })
 
-const initObserver = () => {
-  observeMe.value = document.getElementById('NavJumpMenu')
-  observer.value = new IntersectionObserver(
-    ([e]) => {
-      // console.log('bounding rect top', e.boundingClientRect.top)
-      console.log('reg-intersecting?', e.isIntersecting)
-      console.log('reg:', e.intersectionRatio)
-      // e.target.classList.toggle('-force-hide-jump-menu', e.intersectionRatio === 0)
-      e.target.classList.toggle('-is-sticky', e.intersectionRatio === 0)
-    },
-    {
-      threshold: [0]
-    }
-  )
-  console.log(observer.value)
-  observerOffset.value = new IntersectionObserver(
-    ([e]) => {
-      // console.log('offset: bounding rect top', e.boundingClientRect.top)
-      console.log('offset-intersecting?', e.isIntersecting)
-      console.log('offset:', e.intersectionRatio)
-      // if (e.isIntersecting) {
-      //   e.target.classList.remove('-force-hide-jump-menu-offset')
-      // } else {
-      //   e.target.classList.add('-force-hide-jump-menu-offset')
-      // }
-      // if (e.boundingClientRect.top < 0) {
-      //   //if (e.isIntersecting) {
-      //   // scrolling up
-      //   e.target.classList.add('-TESTTEST')
-      //   //} else {
-      //   // scrolling down
-      //   //}
-      // } else {
-      //   e.target.classList.remove('-TESTTEST')
-      // }
-      // e.target.classList.toggle('-force-show-jump-menu-offset', e.intersectionRatio === 0)
-      e.target.classList.toggle('-is-sticky-offset', e.intersectionRatio === 0)
-    },
-    {
-      threshold: [0],
-      rootMargin: '-73px 0px 0px 0px'
-    }
-  )
-  console.log(observerOffset.value)
-}
-
 defineExpose({
   NavJumpMenuRef
 })
 onMounted(() => {
   mixinUpdateSecondary(theBreadcrumbs.value, true)
-  initObserver()
-  // const observeMe = document.getElementById('NavSecondary')
-  // if (observeMe) {
-  // if (NavJumpMenuRef.value?.refs?.NavSecondary) {
-  observer.value.observe(observeMe.value)
-  observerOffset.value.observe(observeMe.value)
-  // }
-  // }
 })
 
 const route = useRoute()
@@ -190,29 +133,10 @@ watch(
 <style lang="scss">
 .NavJumpMenu {
   &.-hide-until-threshold {
-    // @apply opacity-0 h-0 transition-none overflow-visible pointer-events-none;
-    @apply opacity-0 h-0 transition-all overflow-visible pointer-events-none;
+    @apply opacity-0 h-0 transition-none overflow-visible pointer-events-none;
     &.-is-sticky,
     &.-is-sticky-offset {
-      // @apply opacity-100 transition-opacity pointer-events-auto;
       @apply opacity-100 transition-all pointer-events-auto;
-    }
-    &.-is-sticky,
-    &.-is-sticky-offset {
-      &.-force-hide-jump-menu {
-        @apply opacity-0 #{!important};
-        // @apply transition-none #{!important};
-      }
-    }
-    &.-is-sticky-offset {
-      &.-force-show-jump-menu-offset {
-        @apply opacity-100  #{!important};
-        // @apply transition-none #{!important};
-      }
-      &.-force-show-hide-menu-offset {
-        @apply opacity-0 #{!important};
-        // @apply transition-none #{!important};
-      }
     }
   }
 }

--- a/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
+++ b/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
@@ -81,7 +81,7 @@ const theJumpLinks = computed(() => {
     const links: BreadcrumbPathObject[] = filteredBlocks.map((l) => {
       return {
         // @ts-expect-error using parameter that was added to BlockData
-        path: '#' + getHeadingId(l.heading, l.index),
+        path: '#' + getHeadingId(l.heading, l.blockId),
         title: l.heading
       } as BreadcrumbPathObject
     })

--- a/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
+++ b/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
@@ -122,7 +122,7 @@ const initObserver = () => {
       // console.log('bounding rect top', e.boundingClientRect.top)
       console.log('reg-intersecting?', e.isIntersecting)
       console.log('reg:', e.intersectionRatio)
-      e.target.classList.toggle('-force-hide-jump-menu', e.intersectionRatio === 1)
+      e.target.classList.toggle('-force-hide-jump-menu', e.intersectionRatio === 0)
     },
     {
       threshold: [0]
@@ -149,12 +149,12 @@ const initObserver = () => {
       // } else {
       //   e.target.classList.remove('-TESTTEST')
       // }
-      // e.target.classList.toggle('-force-show-jump-menu-offset', e.intersectionRatio === 1)
+      e.target.classList.toggle('-force-show-jump-menu-offset', e.intersectionRatio === 0)
       // e.target.classList.toggle('-force-hide-jump-menu-offset', e.intersectionRatio === 0)
     },
     {
-      threshold: [1],
-      rootMargin: '0px 0px 0px 0px'
+      threshold: [0],
+      rootMargin: '-70px 0px 0px 0px'
     }
   )
   console.log(observerOffset.value)
@@ -200,17 +200,17 @@ watch(
     &.-is-sticky-offset {
       &.-force-hide-jump-menu {
         @apply opacity-0 #{!important};
-        @apply transition-none #{!important};
+        // @apply transition-none #{!important};
       }
     }
     &.-is-sticky-offset {
       &.-force-show-jump-menu-offset {
         @apply opacity-100  #{!important};
-        @apply transition-none #{!important};
+        // @apply transition-none #{!important};
       }
       &.-force-show-hide-menu-offset {
         @apply opacity-0 #{!important};
-        @apply transition-none #{!important};
+        // @apply transition-none #{!important};
       }
     }
   }

--- a/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
+++ b/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
@@ -122,7 +122,8 @@ const initObserver = () => {
       // console.log('bounding rect top', e.boundingClientRect.top)
       console.log('reg-intersecting?', e.isIntersecting)
       console.log('reg:', e.intersectionRatio)
-      e.target.classList.toggle('-force-hide-jump-menu', e.intersectionRatio === 0)
+      // e.target.classList.toggle('-force-hide-jump-menu', e.intersectionRatio === 0)
+      e.target.classList.toggle('-is-sticky', e.intersectionRatio === 0)
     },
     {
       threshold: [0]
@@ -149,12 +150,12 @@ const initObserver = () => {
       // } else {
       //   e.target.classList.remove('-TESTTEST')
       // }
-      e.target.classList.toggle('-force-show-jump-menu-offset', e.intersectionRatio === 0)
-      // e.target.classList.toggle('-force-hide-jump-menu-offset', e.intersectionRatio === 0)
+      // e.target.classList.toggle('-force-show-jump-menu-offset', e.intersectionRatio === 0)
+      e.target.classList.toggle('-is-sticky-offset', e.intersectionRatio === 0)
     },
     {
       threshold: [0],
-      rootMargin: '-70px 0px 0px 0px'
+      rootMargin: '-73px 0px 0px 0px'
     }
   )
   console.log(observerOffset.value)

--- a/packages/vue/src/components/NavSecondary/NavSecondary.vue
+++ b/packages/vue/src/components/NavSecondary/NavSecondary.vue
@@ -83,7 +83,10 @@ export default defineComponent({
   },
   data() {
     return {
-      isSticky: false
+      isSticky: false,
+      stickyElement: undefined,
+      observer: undefined,
+      observerOffset: undefined
     }
   },
   computed: {
@@ -119,6 +122,7 @@ export default defineComponent({
     ) {
       // intersection observer not supported
     } else if (this.enabled) {
+      this.initIntersectionObservers()
       this.checkSticky()
     }
   },
@@ -129,10 +133,9 @@ export default defineComponent({
       }
       return false
     },
-    checkSticky() {
-      const stickyElement = this.$refs.NavSecondary as HTMLElement
-      // we need both observers for when the global nav is/isn't showing
-      const observer = new IntersectionObserver(
+    initIntersectionObservers() {
+      this.stickyElement = this.$refs.NavSecondary as HTMLElement
+      this.observer = new IntersectionObserver(
         ([e]) => {
           e.target.classList.toggle('-is-sticky', e.intersectionRatio < 1)
         },
@@ -140,18 +143,19 @@ export default defineComponent({
           threshold: [1]
         }
       )
-      const observerOffset = new IntersectionObserver(
+      this.observerOffset = new IntersectionObserver(
         ([e]) => {
           e.target.classList.toggle('-is-sticky-offset', e.intersectionRatio < 1)
         },
         {
           threshold: [1],
-          // would prefer to use rems but intersection observer only works with % or px
-          rootMargin: '-113px 0px 0px 0px'
+          rootMargin: '-113px 0px 0px 0px' // www breadcrumbs
         }
       )
-      observer.observe(stickyElement)
-      observerOffset.observe(stickyElement)
+    },
+    checkSticky() {
+      this.observer.observe(this.stickyElement)
+      this.observerOffset.observe(this.stickyElement)
     }
   }
 })

--- a/packages/vue/src/components/NavSecondary/NavSecondary.vue
+++ b/packages/vue/src/components/NavSecondary/NavSecondary.vue
@@ -122,8 +122,8 @@ export default defineComponent({
     ) {
       // intersection observer not supported
     } else if (this.enabled) {
-      this.initIntersectionObservers()
-      this.checkSticky()
+      // this.initIntersectionObservers()
+      // this.checkSticky()
     }
   },
   methods: {
@@ -149,13 +149,14 @@ export default defineComponent({
         },
         {
           threshold: [1],
-          rootMargin: '-113px 0px 0px 0px' // www breadcrumbs
+          // rootMargin: '-113px 0px 0px 0px' // www breadcrumbs
+          rootMargin: '0px 0px 0px 0px' // www breadcrumbs
         }
       )
     },
     checkSticky() {
-      this.observer.observe(this.stickyElement)
-      this.observerOffset.observe(this.stickyElement)
+      // this.observer.observe(this.stickyElement)
+      // this.observerOffset.observe(this.stickyElement)
     }
   }
 })

--- a/packages/vue/src/components/NavSecondary/NavSecondary.vue
+++ b/packages/vue/src/components/NavSecondary/NavSecondary.vue
@@ -81,7 +81,12 @@ export default defineComponent({
       default: false
     }
   },
-  data() {
+  data(): {
+    isSticky: boolean
+    stickyElement?: HTMLElement
+    observer?: IntersectionObserver
+    observerOffset?: IntersectionObserver
+  } {
     return {
       isSticky: false,
       stickyElement: undefined,
@@ -154,8 +159,10 @@ export default defineComponent({
       )
     },
     checkSticky() {
-      this.observer.observe(this.stickyElement)
-      this.observerOffset.observe(this.stickyElement)
+      if (this.stickyElement) {
+        if (this.observer) this.observer.observe(this.stickyElement)
+        if (this.observerOffset) this.observerOffset.observe(this.stickyElement)
+      }
     }
   }
 })

--- a/packages/vue/src/components/NavSecondary/NavSecondary.vue
+++ b/packages/vue/src/components/NavSecondary/NavSecondary.vue
@@ -122,8 +122,8 @@ export default defineComponent({
     ) {
       // intersection observer not supported
     } else if (this.enabled) {
-      // this.initIntersectionObservers()
-      // this.checkSticky()
+      this.initIntersectionObservers()
+      this.checkSticky()
     }
   },
   methods: {
@@ -137,26 +137,25 @@ export default defineComponent({
       this.stickyElement = this.$refs.NavSecondary as HTMLElement
       this.observer = new IntersectionObserver(
         ([e]) => {
-          e.target.classList.toggle('-is-sticky', e.intersectionRatio < 1)
+          e.target.classList.toggle('-is-sticky', e.intersectionRatio === 0)
         },
         {
-          threshold: [1]
+          threshold: [0]
         }
       )
       this.observerOffset = new IntersectionObserver(
         ([e]) => {
-          e.target.classList.toggle('-is-sticky-offset', e.intersectionRatio < 1)
+          e.target.classList.toggle('-is-sticky-offset', e.intersectionRatio === 0)
         },
         {
-          threshold: [1],
-          // rootMargin: '-113px 0px 0px 0px' // www breadcrumbs
-          rootMargin: '0px 0px 0px 0px' // www breadcrumbs
+          threshold: [0],
+          rootMargin: this.themeStore.isEdu ? '-73px 0px 0px 0px' : '-113px 0px 0px 0px'
         }
       )
     },
     checkSticky() {
-      // this.observer.observe(this.stickyElement)
-      // this.observerOffset.observe(this.stickyElement)
+      this.observer.observe(this.stickyElement)
+      this.observerOffset.observe(this.stickyElement)
     }
   }
 })

--- a/packages/vue/src/components/ShareButtonsEdu/ShareButtonsEdu.vue
+++ b/packages/vue/src/components/ShareButtonsEdu/ShareButtonsEdu.vue
@@ -89,7 +89,7 @@ const buttonClass = computed(() => {
 })
 </script>
 <template>
-  <div class="ShareButtonsEdu relative flex flex-row items-start border-collapse print:hidden">
+  <div class="ShareButtonsEdu relative z-30 flex flex-row items-start border-collapse print:hidden">
     <BaseButton
       variant="social"
       :class="buttonClass"

--- a/packages/vue/src/interfaces.ts
+++ b/packages/vue/src/interfaces.ts
@@ -199,3 +199,14 @@ export interface AccordionItemObject {
   title?: string
   body?: StreamfieldBlockData[]
 }
+
+export type MetaPanelTheme = 'primary' | 'secondary' | 'stars'
+
+export interface EduStandard {
+  type: string
+  code: string
+  domain: {
+    domain: string
+  }
+  definition: string
+}

--- a/packages/vue/src/interfaces.ts
+++ b/packages/vue/src/interfaces.ts
@@ -15,6 +15,24 @@ export interface BlockData {
   level?: string
   items?: any[]
 }
+export interface StreamfieldBlockData extends BlockData {
+  id: string
+  fullBleed: boolean
+  heading: string
+  galleryTitle: string
+  galleryDescription: string
+  coverImage: ImageObject
+  gallerySlides: ImageObject[]
+  blocks: object[]
+  value: string
+  customLabel: string
+  introduction: string
+  teaserPage: object | string[]
+  image: ImageObject
+  buttonText: string
+  fullWidthImage: boolean
+}
+
 export interface ImageSrcObject {
   url: string
   width: number
@@ -176,4 +194,8 @@ export interface PillDictionaryInterface {
 }
 export interface DictionaryInterface {
   [key: string]: string
+}
+export interface AccordionItemObject {
+  title?: string
+  body?: StreamfieldBlockData[]
 }

--- a/packages/vue/src/interfaces.ts
+++ b/packages/vue/src/interfaces.ts
@@ -143,17 +143,14 @@ export interface RelatedLinkObject extends LinkObject {
   document: { url: string } | null
   text: string | null
 }
-
-export interface PageResponseObject {
-  __typename: string
-  contentType: string
-  breadcrumb?: string
-  url?: string
+export interface BlockRelatedLinksObject extends BlockData {
+  heading: string
+  links: RelatedLinkObject[]
 }
 
 export interface PageResponse {
   __typename: string
-  page: PageResponseObject
+  page: PageObject
 }
 
 export interface HeaderResponse {
@@ -209,4 +206,53 @@ export interface EduStandard {
     domain: string
   }
   definition: string
+}
+
+export interface PageObject {
+  __typename: string
+  contentType: string
+  breadcrumb?: string
+  slug: string
+  url: string
+  title: string
+  getTopicsForDisplay?: Topic[]
+  label?: string
+  summary?: string
+  topper?: string
+  seoTitle?: string
+  searchDescription?: string
+  heroPosition?: 'full_bleed' | 'inline'
+  heroConstrain?: boolean
+  publicationDate?: string
+  body?: StreamfieldBlockData[]
+  thumbnailImage?: ThumbnailObject
+  relatedLinks?: BlockRelatedLinksObject
+  relatedContent?: any
+}
+
+export interface EduResourcesSubject {
+  subject: string
+}
+export interface EduResourcesGradeLevel {
+  gradeLevel: string
+}
+
+export interface EduResourcesTime {
+  time: string
+}
+export interface EduResourceStandard {
+  code: string
+  definition: string
+  domain: {
+    domain: string
+  }
+  type: string
+}
+export interface PageEduResourcesObject extends PageObject {
+  hero?: StreamfieldBlockData[]
+  primarySubject?: EduResourcesSubject
+  additionalSubjects?: EduResourcesSubject[]
+  gradeLevels?: EduResourcesGradeLevel[]
+  time?: EduResourcesTime
+  standards: EduResourceStandard[]
 }

--- a/packages/vue/src/interfaces.ts
+++ b/packages/vue/src/interfaces.ts
@@ -16,21 +16,28 @@ export interface BlockData {
   items?: any[]
 }
 export interface StreamfieldBlockData extends BlockData {
-  id: string
-  fullBleed: boolean
-  heading: string
-  galleryTitle: string
-  galleryDescription: string
-  coverImage: ImageObject
-  gallerySlides: ImageObject[]
-  blocks: object[]
-  value: string
-  customLabel: string
-  introduction: string
-  teaserPage: object | string[]
-  image: ImageObject
-  buttonText: string
-  fullWidthImage: boolean
+  blockId?: string
+  id?: string
+  fullBleed?: boolean
+  heading?: string
+  galleryTitle?: string
+  galleryDescription?: string
+  coverImage?: ImageObject
+  gallerySlides?: ImageObject[]
+  blocks?: object[]
+  value?: string
+  customLabel?: string
+  introduction?: string
+  teaserPage?: object | string[]
+  image?: ImageObject
+  buttonText?: string
+  fullWidthImage?: boolean
+  video?: any
+  embed?: any
+  displayCaption?: boolean
+  caption?: string
+  credit?: string
+  imageInline?: ImageObject
 }
 
 export interface ImageSrcObject {
@@ -167,7 +174,7 @@ export interface FooterResponse {
 export type Explorer1Theme = 'defaultTheme' | 'ThemeInternal' | 'ThemeEdu'
 
 export interface Attributes {
-  [name: string]: string
+  [key: string]: string
 }
 
 export interface AuthorObject {
@@ -199,15 +206,6 @@ export interface AccordionItemObject {
 
 export type MetaPanelTheme = 'primary' | 'secondary' | 'stars'
 
-export interface EduStandard {
-  type: string
-  code: string
-  domain: {
-    domain: string
-  }
-  definition: string
-}
-
 export interface PageObject {
   __typename: string
   contentType: string
@@ -226,7 +224,8 @@ export interface PageObject {
   publicationDate?: string
   body?: StreamfieldBlockData[]
   thumbnailImage?: ThumbnailObject
-  relatedLinks?: BlockRelatedLinksObject
+  relatedLinks?: BlockRelatedLinksObject[]
+  relatedContentHeading: string
   relatedContent?: any
 }
 
@@ -241,18 +240,23 @@ export interface EduResourcesTime {
   time: string
 }
 export interface EduResourceStandard {
+  type: string
   code: string
-  definition: string
   domain: {
     domain: string
   }
-  type: string
+  definition: string
 }
+
+export interface EduResourceStandardItem {
+  standard: EduResourceStandard
+}
+
 export interface PageEduResourcesObject extends PageObject {
   hero?: StreamfieldBlockData[]
   primarySubject?: EduResourcesSubject
   additionalSubjects?: EduResourcesSubject[]
   gradeLevels?: EduResourcesGradeLevel[]
   time?: EduResourcesTime
-  standards: EduResourceStandard[]
+  standards: EduResourceStandardItem[]
 }

--- a/packages/vue/src/main.ts
+++ b/packages/vue/src/main.ts
@@ -6,6 +6,7 @@ import filters from './utils/filters'
 // @ts-ignore
 import vClickOutside from 'click-outside-vue3'
 import VueCompareImage from 'vue3-compare-image'
+import { BindOncePlugin } from 'vue-bind-once'
 import './assets/scss/styles-with-fonts.scss'
 import App from './App.vue'
 
@@ -23,6 +24,7 @@ app.use(pinia)
 app.use(router)
 app.use(vClickOutside)
 app.use(VueCompareImage)
+app.use(BindOncePlugin)
 
 // filters
 app.config.globalProperties.$filters = filters

--- a/packages/vue/src/templates/edu/PageEduExplainerArticle/PageEduExplainerArticle.stories.js
+++ b/packages/vue/src/templates/edu/PageEduExplainerArticle/PageEduExplainerArticle.stories.js
@@ -47,6 +47,7 @@ export const BaseStory = {
           blockType: 'HeroImageBlock'
         }
       ],
+      showJumpMenu: true,
       ...BlockStreamfieldTruncatedData,
       publicationDate: '2024-07-09',
       summary: 'Summary of resource article',

--- a/packages/vue/src/templates/edu/PageEduExplainerArticle/PageEduExplainerArticle.vue
+++ b/packages/vue/src/templates/edu/PageEduExplainerArticle/PageEduExplainerArticle.vue
@@ -5,6 +5,7 @@ import BaseImagePlaceholder from './../../../components/BaseImagePlaceholder/Bas
 import BlockImageCarousel from './../../../components/BlockImageCarousel/BlockImageCarousel.vue'
 import BlockImageComparison from './../../../components/BlockImageComparison/BlockImageComparison.vue'
 import BlockLinkCarousel from './../../../components/BlockLinkCarousel/BlockLinkCarousel.vue'
+import BlockVideo from './../../../components/BlockVideo/BlockVideo.vue'
 import LayoutHelper from './../../../components/LayoutHelper/LayoutHelper.vue'
 import DetailHeadline from './../../../components/DetailHeadline/DetailHeadline.vue'
 import BlockImageStandard from './../../../components/BlockImage/BlockImageStandard.vue'
@@ -12,6 +13,7 @@ import ShareButtonsEdu from './../../../components/ShareButtonsEdu/ShareButtonsE
 import BlockStreamfield from './../../../components/BlockStreamfield/BlockStreamfield.vue'
 import BlockIframeEmbed from '../../../components/BlockIframeEmbed/BlockIframeEmbed.vue'
 import BlockRelatedLinks from '../../../components/BlockRelatedLinks/BlockRelatedLinks.vue'
+import NavJumpMenu from './../../../components/NavJumpMenu/NavJumpMenu.vue'
 
 export default defineComponent({
   name: 'PageEduExplainerArticle',
@@ -27,7 +29,9 @@ export default defineComponent({
     BlockImageCarousel,
     BlockImageComparison,
     BlockLinkCarousel,
-    BlockRelatedLinks
+    BlockRelatedLinks,
+    BlockVideo,
+    NavJumpMenu
   },
   props: {
     data: {
@@ -121,6 +125,11 @@ export default defineComponent({
       />
     </LayoutHelper>
 
+    <NavJumpMenu
+      :title="data.title"
+      :blocks="data.body"
+      :enabled="data.showJumpMenu"
+    />
     <!-- inline hero content -->
     <LayoutHelper
       v-if="!heroEmpty && heroInline"

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.stories.js
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.stories.js
@@ -166,13 +166,19 @@ export const BaseStory = {
 
       procedures: [
         {
-          procedure: BlockStreamfieldMinimalData.body
+          procedure: {
+            blocks: BlockStreamfieldMinimalData.body
+          }
         },
         {
-          procedure: BlockStreamfieldMinimalData.body
+          procedure: {
+            blocks: BlockStreamfieldMinimalData.body
+          }
         },
         {
-          procedure: BlockStreamfieldMinimalData.body
+          procedure: {
+            blocks: BlockStreamfieldMinimalData.body
+          }
         }
       ],
       proceduresHeading: 'Procedures heading',

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.stories.js
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.stories.js
@@ -1,18 +1,22 @@
 import { HeroMediaData } from './../../../components/HeroMedia/HeroMedia.stories'
 import { BlockIframeEmbedData } from './../../../components/BlockIframeEmbed/BlockIframeEmbed.stories.js'
 import { BlockImageCarouselData } from './../../../components/BlockImageCarousel/BlockImageCarousel.stories'
+import { BlockImageData } from './../../../components/BlockImage/BlockImage.stories'
+import { BlockHeadingData } from './../../../components/BlockHeading/BlockHeading.stories'
 import { BlockImageComparisonData } from './../../../components/BlockImageComparison/BlockImageComparison.stories'
 import { BaseVideoData } from './../../../components/BaseVideo/BaseVideo.stories'
 import { BlockVideoEmbedData } from './../../../components/BlockVideoEmbed/BlockVideoEmbed.stories'
-
 import { BlockRelatedLinksData } from './../../../components/BlockRelatedLinks/BlockRelatedLinks.stories.js'
 import { BlockLinkCardCarouselData } from './../../../components/BlockLinkCarousel/BlockLinkCarousel.stories.js'
-import { BlockStreamfieldTruncatedData } from './../../../components/BlockStreamfield/BlockStreamfield.stories'
-import PageEduExplainerArticle from './PageEduExplainerArticle.vue'
+import {
+  BlockStreamfieldTruncatedData,
+  BlockStreamfieldMinimalData
+} from './../../../components/BlockStreamfield/BlockStreamfield.stories'
+import PageEduLesson from './PageEduLesson.vue'
 
 export default {
-  title: 'Templates/EDU/PageEduExplainerArticle',
-  component: PageEduExplainerArticle,
+  title: 'Templates/EDU/PageEduLesson',
+  component: PageEduLesson,
   decorators: [
     () => ({
       template: `<div id="storyDecorator" class="disable-nav-offset"><story/></div>`
@@ -30,74 +34,173 @@ export default {
 export const BaseStory = {
   args: {
     data: {
-      __typename: 'EDUExplainerArticlePage',
+      __typename: 'EDULessonPage',
+      title: 'Test Lesson',
+      url: 'http://localhost:3000/edu/resources/test-lesson',
       pageType: 'EDUExplainerArticlePage',
       contentType: 'edu_resources.EDUExplainerArticlePage',
-      seoTitle: 'Test Resource',
       searchDescription: '',
-      slug: 'test-resource',
-      url: 'http://localhost:3000/edu/resources/test-resource',
-      title: 'Test Resource',
-      readTime: '6 min read',
-      heroConstrain: true,
-      heroPosition: 'full_bleed',
+      seoTitle: 'Test Lesson',
+      slug: 'test-lesson',
+      publicationDate: '2024-08-16',
+      thumbnailImage: {
+        __typename: 'CustomImage',
+        original: 'http://127.0.0.1:9000/media/original_images/imagessirtfsirtf-090303-16.jpg',
+        alt: ''
+      },
       hero: [
         {
           ...HeroMediaData,
           blockType: 'HeroImageBlock'
         }
       ],
-      ...BlockStreamfieldTruncatedData,
-      publicationDate: '2024-07-09',
-      summary: 'Summary of resource article',
-      getTopicsForDisplay: [
-        {
-          __typename: 'TopicPage',
-          title: 'Asteroids',
-          url: 'http://localhost:3000/topics/asteroids'
-        }
-      ],
-      topicLabel: 'Asteroids',
+      heroConstrain: true,
+      heroPosition: 'full_bleed',
+
+      studentProject: {
+        title: 'Student Project',
+        urlPath: '/path-to-student-project'
+      },
+
       primarySubject: {
-        __typename: 'EDUPrimarySubject',
-        id: '2',
-        subject: 'Engineering'
+        subject: 'Arts'
       },
       additionalSubjects: [
         {
-          __typename: 'EDUPrimarySubject',
-          id: '1',
-          subject: 'Art'
+          subject: 'Science'
         }
       ],
       gradeLevels: [
         {
-          __typename: 'EDUGradeLevel',
-          id: '2',
           gradeLevel: 'K'
         },
         {
-          __typename: 'EDUGradeLevel',
-          id: '3',
           gradeLevel: '1'
-        },
-        {
-          __typename: 'EDUGradeLevel',
-          id: '4',
-          gradeLevel: '2'
-        },
-        {
-          __typename: 'EDUGradeLevel',
-          id: '13',
-          gradeLevel: '11'
         }
       ],
-      body: BlockStreamfieldTruncatedData.body,
-      thumbnailImage: {
-        __typename: 'CustomImage',
-        original: 'http://127.0.0.1:9000/media/original_images/imagessirtfsirtf-090303-16.jpg',
-        alt: ''
+      time: {
+        time: 'Under 30 mins'
       },
+      standards: [
+        {
+          standard: {
+            code: 'CCRA.R.1',
+            definition:
+              'Read closely to determine what the text says explicitly and to make logical inferences from it; cite specific textual evidence when writing or speaking to support conclusions drawn from the text.',
+            domain: {
+              domain: 'College and Career Readiness Anchor Standards for Reading'
+            },
+            type: 'ccss_english_language_arts'
+          }
+        },
+        {
+          standard: {
+            code: 'RL.3.2',
+            definition:
+              'Recount stories, including fables, folktales, and myths from diverse cultures; determine the central message, lesson, or moral and explain how it is conveyed through key details in the text.',
+            domain: {
+              domain: 'Reading Standards for Literature'
+            },
+            type: 'ccss_english_language_arts'
+          }
+        },
+        {
+          standard: {
+            code: 'RL.1.5',
+            definition:
+              'Explain major differences between books that tell stories and books that give information, drawing on a wide reading of a range of text types.',
+            domain: {
+              domain: 'Reading Standards for Literature'
+            },
+            type: 'ccss_english_language_arts'
+          }
+        },
+        {
+          standard: {
+            code: 'K.CC.A',
+            definition: 'Know number names and the count sequence.',
+            domain: {
+              domain: 'Counting and Cardinality'
+            },
+            type: 'ccss_maths'
+          }
+        },
+        {
+          standard: {
+            code: 'K.CC.A.3',
+            definition:
+              'Write numbers from 0 to 20. Represent a number of objects with a written numeral 0-20 (with 0 representing a count of no objects).',
+            domain: {
+              domain: 'Counting and Cardinality'
+            },
+            type: 'ccss_maths'
+          }
+        },
+        {
+          standard: {
+            code: 'K-PS2-1',
+            definition:
+              'Plan and conduct an investigation to compare the effects of different strengths or different directions of pushes and pulls on the motion of an object.',
+            domain: {
+              domain: 'Physical Sciences'
+            },
+            type: 'ngss'
+          }
+        }
+      ],
+
+      overview: BlockStreamfieldMinimalData.body,
+      overviewHeading: 'Custom Overview heading',
+      overviewImage: BlockImageData.image,
+
+      materials:
+        '<ul><li data-block-key="nvq4l">list item one</li><li data-block-key="efmt7">list item two</li><li data-block-key="d0f66">list item three this one is really long and the text just keeps on going lorem ipsum dolor sit amet consectatur</li></ul><p data-block-key="bksrq">Paragraph to appear below.</p>',
+      materialsHeading: 'Materials stuff',
+      materialsImage: BlockImageData.image,
+
+      management: BlockStreamfieldMinimalData.body,
+      managementHeading: 'Management stuff',
+
+      background: BlockStreamfieldMinimalData.body,
+      backgroundHeading: 'Background heading',
+
+      procedures: [
+        {
+          procedure: BlockStreamfieldMinimalData.body
+        },
+        {
+          procedure: BlockStreamfieldMinimalData.body
+        },
+        {
+          procedure: BlockStreamfieldMinimalData.body
+        }
+      ],
+      proceduresHeading: 'Procedures heading',
+      proceduresStepsNumbering: true,
+
+      discussion: BlockStreamfieldMinimalData.body,
+      discussionHeading: 'Discussion heading',
+
+      assessment: BlockStreamfieldMinimalData.body,
+      assessmentHeading: 'Assessment heading',
+
+      extensions: BlockStreamfieldMinimalData.body,
+      extensionsHeading: 'Extensions heading',
+
+      techAddons: BlockStreamfieldMinimalData.body,
+      techAddonsHeading: 'Tech addons heading',
+
+      customSections: [
+        {
+          blockType: 'EDULessonCustomSectionBlock',
+          content: BlockStreamfieldTruncatedData.body,
+          heading: BlockHeadingData,
+          position: 'after_procedures'
+        }
+      ],
+
+      body: BlockStreamfieldTruncatedData.body,
+
       relatedLinks: BlockRelatedLinksData.data,
       relatedContentHeading: 'Related Content',
       relatedContent: BlockLinkCardCarouselData

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.stories.js
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.stories.js
@@ -1,0 +1,194 @@
+import { HeroMediaData } from './../../../components/HeroMedia/HeroMedia.stories'
+import { BlockIframeEmbedData } from './../../../components/BlockIframeEmbed/BlockIframeEmbed.stories.js'
+import { BlockImageCarouselData } from './../../../components/BlockImageCarousel/BlockImageCarousel.stories'
+import { BlockImageComparisonData } from './../../../components/BlockImageComparison/BlockImageComparison.stories'
+import { BaseVideoData } from './../../../components/BaseVideo/BaseVideo.stories'
+import { BlockVideoEmbedData } from './../../../components/BlockVideoEmbed/BlockVideoEmbed.stories'
+
+import { BlockRelatedLinksData } from './../../../components/BlockRelatedLinks/BlockRelatedLinks.stories.js'
+import { BlockLinkCardCarouselData } from './../../../components/BlockLinkCarousel/BlockLinkCarousel.stories.js'
+import { BlockStreamfieldTruncatedData } from './../../../components/BlockStreamfield/BlockStreamfield.stories'
+import PageEduExplainerArticle from './PageEduExplainerArticle.vue'
+
+export default {
+  title: 'Templates/EDU/PageEduExplainerArticle',
+  component: PageEduExplainerArticle,
+  decorators: [
+    () => ({
+      template: `<div id="storyDecorator" class="disable-nav-offset"><story/></div>`
+    })
+  ],
+  parameters: {
+    layout: 'fullscreen',
+    html: {
+      root: '#storyDecorator'
+    }
+  },
+  excludeStories: /.*Data$/
+}
+
+export const BaseStory = {
+  args: {
+    data: {
+      __typename: 'EDUExplainerArticlePage',
+      pageType: 'EDUExplainerArticlePage',
+      contentType: 'edu_resources.EDUExplainerArticlePage',
+      seoTitle: 'Test Resource',
+      searchDescription: '',
+      slug: 'test-resource',
+      url: 'http://localhost:3000/edu/resources/test-resource',
+      title: 'Test Resource',
+      readTime: '6 min read',
+      heroConstrain: true,
+      heroPosition: 'full_bleed',
+      hero: [
+        {
+          ...HeroMediaData,
+          blockType: 'HeroImageBlock'
+        }
+      ],
+      ...BlockStreamfieldTruncatedData,
+      publicationDate: '2024-07-09',
+      summary: 'Summary of resource article',
+      getTopicsForDisplay: [
+        {
+          __typename: 'TopicPage',
+          title: 'Asteroids',
+          url: 'http://localhost:3000/topics/asteroids'
+        }
+      ],
+      topicLabel: 'Asteroids',
+      primarySubject: {
+        __typename: 'EDUPrimarySubject',
+        id: '2',
+        subject: 'Engineering'
+      },
+      additionalSubjects: [
+        {
+          __typename: 'EDUPrimarySubject',
+          id: '1',
+          subject: 'Art'
+        }
+      ],
+      gradeLevels: [
+        {
+          __typename: 'EDUGradeLevel',
+          id: '2',
+          gradeLevel: 'K'
+        },
+        {
+          __typename: 'EDUGradeLevel',
+          id: '3',
+          gradeLevel: '1'
+        },
+        {
+          __typename: 'EDUGradeLevel',
+          id: '4',
+          gradeLevel: '2'
+        },
+        {
+          __typename: 'EDUGradeLevel',
+          id: '13',
+          gradeLevel: '11'
+        }
+      ],
+      body: BlockStreamfieldTruncatedData.body,
+      thumbnailImage: {
+        __typename: 'CustomImage',
+        original: 'http://127.0.0.1:9000/media/original_images/imagessirtfsirtf-090303-16.jpg',
+        alt: ''
+      },
+      relatedLinks: BlockRelatedLinksData.data,
+      relatedContentHeading: 'Related Content',
+      relatedContent: BlockLinkCardCarouselData
+    }
+  }
+}
+export const InlineHero = {
+  args: {
+    data: {
+      ...BaseStory.args.data,
+      heroPosition: 'inline'
+    }
+  }
+}
+
+export const HeroCarousel = {
+  args: {
+    data: {
+      ...BaseStory.args.data,
+      hero: [{ blockType: 'CarouselBlock', blocks: BlockImageCarouselData }]
+    }
+  }
+}
+
+export const HeroImageComparison = {
+  args: {
+    data: {
+      ...BaseStory.args.data,
+      heroPosition: 'inline',
+      hero: [
+        {
+          ...BlockImageComparisonData
+        }
+      ]
+    }
+  }
+}
+
+export const HeroVideo = {
+  args: {
+    data: {
+      ...BaseStory.args.data,
+      hero: [
+        {
+          blockType: 'VideoBlock',
+          video: BaseVideoData,
+          caption: 'Lorem ipsum dolor sit amet',
+          credit: 'NASA/JPL'
+        }
+      ]
+    }
+  }
+}
+
+export const HeroVideoEmbed = {
+  args: {
+    data: {
+      ...BaseStory.args.data,
+      heroPosition: 'inline',
+      hero: [
+        {
+          ...BlockVideoEmbedData.data,
+          embed: {
+            embed: `<iframe title="Meet NASA's Diana Trujillo - Embedded Hero" width="480" height="270" src="https://www.youtube.com/embed/vUuUyYqI83Q?feature=oembed" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`
+          },
+          blockType: 'VideoEmbedBlock'
+        }
+      ]
+    }
+  }
+}
+
+export const HeroIframeEmbed = {
+  args: {
+    data: {
+      ...BaseStory.args.data,
+      heroPosition: 'inline',
+      hero: [
+        {
+          ...BlockIframeEmbedData
+        }
+      ]
+    }
+  }
+}
+
+export const NoHero = {
+  args: {
+    data: {
+      ...BaseStory.args.data,
+      hero: []
+    }
+  }
+}

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
@@ -11,6 +11,7 @@ import BaseImagePlaceholder from './../../../components/BaseImagePlaceholder/Bas
 import BlockImageCarousel from './../../../components/BlockImageCarousel/BlockImageCarousel.vue'
 import BlockImageComparison from './../../../components/BlockImageComparison/BlockImageComparison.vue'
 import BlockLinkCarousel from './../../../components/BlockLinkCarousel/BlockLinkCarousel.vue'
+import BlockVideo from './../../../components/BlockVideo/BlockVideo.vue'
 import LayoutHelper from './../../../components/LayoutHelper/LayoutHelper.vue'
 import DetailHeadline from './../../../components/DetailHeadline/DetailHeadline.vue'
 import BlockImageStandard from './../../../components/BlockImage/BlockImageStandard.vue'
@@ -210,7 +211,7 @@ const consolidatedSections = computed(() => {
     :class="computedClass"
   >
     <LayoutHelper
-      indent="col-2"
+      indent="col-3"
       class="mb-10"
     >
       <DetailHeadline
@@ -247,6 +248,7 @@ const consolidatedSections = computed(() => {
       :grade-levels="data.gradeLevels"
       :standards="data.standards"
       negative-bottom
+      theme="stars"
     />
 
     <!-- hero media -->
@@ -310,44 +312,45 @@ const consolidatedSections = computed(() => {
       :blocks="consolidatedBlocks"
       :enabled="true"
     />
+    <div id="NavJumpMenuFrame">
+      <template
+        v-for="(value, key) in consolidatedSections"
+        :key="key"
+      >
+        <BlockStreamfield
+          v-if="value.type === 'streamfield'"
+          :data="value.blocks"
+        />
+        <PageEduLessonSection
+          v-else
+          :heading="value.heading"
+          :blocks="value.blocks"
+          :procedures="value.procedures"
+          :procedure-steps="value.procedureSteps"
+          :text="value.text"
+          :image="value.image"
+        />
+      </template>
 
-    <template
-      v-for="(value, key) in consolidatedSections"
-      :key="key"
-    >
-      <BlockStreamfield
-        v-if="value.type === 'streamfield'"
-        :data="value.blocks"
+      <!-- streamfield blocks -->
+      <BlockStreamfield :data="data.body" />
+
+      <!-- related links -->
+      <LayoutHelper
+        v-if="data.relatedLinks && data.relatedLinks.length"
+        indent="col-3"
+        class="lg:my-18 my-10"
+      >
+        <BlockRelatedLinks :data="data.relatedLinks[0]" />
+      </LayoutHelper>
+
+      <!-- related content -->
+      <BlockLinkCarousel
+        item-type="cards"
+        class="lg:my-24 my-12 print:px-4"
+        :heading="data.relatedContentHeading"
+        :items="data.relatedContent"
       />
-      <PageEduLessonSection
-        v-else
-        :heading="value.heading"
-        :blocks="value.blocks"
-        :procedures="value.procedures"
-        :procedure-steps="value.procedureSteps"
-        :text="value.text"
-        :image="value.image"
-      />
-    </template>
-
-    <!-- streamfield blocks -->
-    <BlockStreamfield :data="data.body" />
-
-    <!-- related links -->
-    <LayoutHelper
-      v-if="data.relatedLinks && data.relatedLinks.length"
-      indent="col-3"
-      class="lg:my-18 my-10"
-    >
-      <BlockRelatedLinks :data="data.relatedLinks[0]" />
-    </LayoutHelper>
-
-    <!-- related content -->
-    <BlockLinkCarousel
-      item-type="cards"
-      class="lg:my-24 my-12 print:px-4"
-      :heading="data.relatedContentHeading"
-      :items="data.relatedContent"
-    />
+    </div>
   </div>
 </template>

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
@@ -64,10 +64,10 @@ defineExpose({
   PageEduLessonJumpMenu
 })
 
-const stringAsHeadingBlockData = (heading) => {
+const stringAsHeadingBlockData = (heading, overrideText) => {
   return {
     blockType: 'HeadingBlock',
-    heading: heading,
+    heading: overrideText || heading,
     level: 'h2'
   }
 }
@@ -117,10 +117,9 @@ const sectionOrder = [
 // mimic HeadingBlock data shape for defined section headings
 const staticSectionHeadings = computed(() => {
   const result = sectionOrder.reduce((acc, section) => {
-    acc[section] = stringAsHeadingBlockData(
-      data[`${section}Heading`],
-      section.charAt(0).toUpperCase() + section.slice(1)
-    )
+    const headingText =
+      section === 'techAddons' ? 'Tech Add-ons' : section.charAt(0).toUpperCase() + section.slice(1)
+    acc[section] = stringAsHeadingBlockData(data[`${section}Heading`] || headingText)
     return acc
   }, {})
   return result
@@ -152,10 +151,12 @@ const consolidatedBlocks = computed(() => {
       blocks.push(staticSectionHeadings.value[section])
       if (section !== 'materials' && section !== 'procedures') {
         blocks.push(...data[section])
-      } else if (section === 'procedures') {
+      } else if (section === 'procedures' && data.procedures?.length) {
         // get blocks in nested procedures
         data.procedures.forEach((item) => {
-          blocks.push(...item.procedure)
+          if (item.procedure) {
+            blocks.push(...item.procedure)
+          }
         })
       }
     }

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
@@ -1,6 +1,12 @@
-<script lang="ts">
-import { defineComponent } from 'vue'
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue'
+import type {
+  ImageObject,
+  PageEduResourcesObject,
+  StreamfieldBlockData
+} from './../../../interfaces'
 import HeroMedia from './../../../components/HeroMedia/HeroMedia.vue'
+import BaseLink from './../../../components/BaseLink/BaseLink.vue'
 import BaseImagePlaceholder from './../../../components/BaseImagePlaceholder/BaseImagePlaceholder.vue'
 import BlockImageCarousel from './../../../components/BlockImageCarousel/BlockImageCarousel.vue'
 import BlockImageComparison from './../../../components/BlockImageComparison/BlockImageComparison.vue'
@@ -12,57 +18,129 @@ import ShareButtonsEdu from './../../../components/ShareButtonsEdu/ShareButtonsE
 import BlockStreamfield from './../../../components/BlockStreamfield/BlockStreamfield.vue'
 import BlockIframeEmbed from '../../../components/BlockIframeEmbed/BlockIframeEmbed.vue'
 import BlockRelatedLinks from '../../../components/BlockRelatedLinks/BlockRelatedLinks.vue'
+import MetaPanel from '../../../components/MetaPanel/MetaPanel.vue'
+import PageEduLessonSection from './PageEduLessonSection.vue'
+import NavJumpMenu from './../../../components/NavJumpMenu/NavJumpMenu.vue'
 
-export default defineComponent({
-  name: 'PageEduExplainerArticle',
-  components: {
-    HeroMedia,
-    BaseImagePlaceholder,
-    LayoutHelper,
-    DetailHeadline,
-    BlockImageStandard,
-    BlockIframeEmbed,
-    ShareButtonsEdu,
-    BlockStreamfield,
-    BlockImageCarousel,
-    BlockImageComparison,
-    BlockLinkCarousel,
-    BlockRelatedLinks
-  },
-  props: {
-    data: {
-      type: Object,
-      required: false,
-      default: undefined
-    }
-  },
-  computed: {
-    heroEmpty(): boolean {
-      return (this.data?.hero || []).length === 0
-    },
-    heroInline(): boolean {
-      if (!this.heroEmpty) {
-        if (this.data?.hero[0].blockType === 'VideoBlock') {
-          return false
-        } else if (
-          this.data?.heroPosition === 'inline' ||
-          this.data?.hero[0].blockType === 'CarouselBlock' ||
-          this.data?.hero[0].blockType === 'VideoEmbedBlock'
-        ) {
-          return true
-        }
-      }
+interface PageEduLessonObject extends PageEduResourcesObject {
+  overview: StreamfieldBlockData[]
+  overviewHeading: string
+  overviewImage: ImageObject
+  materials: string
+  materialsHeading: string
+  materialsImage: ImageObject
+  management: StreamfieldBlockData[]
+  managementHeading: string
+  background: StreamfieldBlockData[]
+  backgroundHeading: string
+  procedures: StreamfieldBlockData[]
+  proceduresHeading: string
+  proceduresStepsNumbering: boolean
+  discussion: StreamfieldBlockData[]
+  discussionHeading: string
+  assessment: StreamfieldBlockData[]
+  assessmentHeading: string
+  extensions: StreamfieldBlockData[]
+  extensionsHeading: string
+  techAddons: StreamfieldBlockData[]
+  techAddonsHeading: string
+  customSections: any
+  body: StreamfieldBlockData[]
+}
+interface PageEduLessonProps {
+  data?: PageEduLessonObject
+}
+
+const props = withDefaults(defineProps<PageEduLessonProps>(), {
+  data: undefined
+})
+
+const { data } = reactive(props)
+
+const PageEduLessonJumpMenu = ref()
+
+defineExpose({
+  PageEduLessonJumpMenu
+})
+
+const stringAsHeadingBlockData = (heading, index) => {
+  return {
+    blockType: 'HeadingBlock',
+    heading: heading,
+    level: 'h2',
+    index
+  }
+}
+
+const heroEmpty = computed((): boolean => {
+  return (data?.hero || []).length === 0
+})
+
+const heroInline = computed((): boolean => {
+  if (!heroEmpty.value) {
+    if (data?.hero[0].blockType === 'VideoBlock') {
       return false
-    },
-    computedClass(): string {
-      if (this.heroInline || this.heroEmpty) {
-        return 'pt-5 lg:pt-12'
-      } else if (!this.heroInline) {
-        return '-nav-offset'
-      }
-      return ''
+    } else if (
+      data?.heroPosition === 'inline' ||
+      data?.hero[0].blockType === 'CarouselBlock' ||
+      data?.hero[0].blockType === 'VideoEmbedBlock'
+    ) {
+      return true
     }
   }
+  return false
+})
+
+const computedClass = computed((): string => {
+  if (heroInline.value || heroEmpty) {
+    return 'pt-5 lg:pt-12'
+  } else if (!heroInline.value) {
+    return '-nav-offset'
+  }
+  return ''
+})
+
+const overviewHeading = computed(() => {
+  return stringAsHeadingBlockData(data.overviewHeading || 'Overview', 0)
+})
+const materialsHeading = computed(() => {
+  return stringAsHeadingBlockData(data.materialsHeading || 'Materials', 1)
+})
+const managementHeading = computed(() => {
+  return stringAsHeadingBlockData(data.managementHeading || 'Management', 2)
+})
+const backgroundHeading = computed(() => {
+  return stringAsHeadingBlockData(data.backgroundHeading || 'Background', 3)
+})
+const proceduresHeading = computed(() => {
+  return stringAsHeadingBlockData(data.proceduresHeading || 'Procedures', 4)
+})
+const discussionHeading = computed(() => {
+  return stringAsHeadingBlockData(data.discussionHeading || 'Discussion', 5)
+})
+const assessmentHeading = computed(() => {
+  return stringAsHeadingBlockData(data.assessmentHeading || 'Assessment', 6)
+})
+const extensionsHeading = computed(() => {
+  return stringAsHeadingBlockData(data.extensionsHeading || 'Extensions', 7)
+})
+const techAddonsHeading = computed(() => {
+  return stringAsHeadingBlockData(data.techAddonsHeading || 'Tech Addons', 8)
+})
+
+// TODO get consistent index numbers if some sections are missing. hmmmmmm
+const headingBlocks = computed(() => {
+  const headings = []
+  if (data.overview) headings.push(overviewHeading.value)
+  if (data.materials) headings.push(materialsHeading.value)
+  if (data.management) headings.push(managementHeading.value)
+  if (data.background) headings.push(backgroundHeading.value)
+  if (data.procedures) headings.push(proceduresHeading.value)
+  if (data.discussion) headings.push(discussionHeading.value)
+  if (data.assessment) headings.push(assessmentHeading.value)
+  if (data.extensions) headings.push(extensionsHeading.value)
+  if (data.techAddons) headings.push(techAddonsHeading.value)
+  return headings
 })
 </script>
 <template>
@@ -70,17 +148,49 @@ export default defineComponent({
     v-if="data"
     class="ThemeVariantLight"
     :class="computedClass"
-    itemscope
-    itemtype="http://schema.org/Article"
   >
-    <!-- schema.org -->
-    <meta
-      v-if="data.thumbnailImage && data.thumbnailImage.original"
-      itemprop="image"
-      :content="data.thumbnailImage.original"
+    <LayoutHelper
+      indent="col-2"
+      class="mb-10"
+    >
+      <DetailHeadline
+        :title="data.title"
+        label="Lesson"
+        pill
+      />
+      <ShareButtonsEdu
+        v-if="data?.url"
+        class="mt-4"
+        :url="data.url"
+        :title="data.title"
+        :image="data.thumbnailImage?.original"
+      />
+      <p
+        v-if="data.studentProject"
+        class="mt-8 font-bold text-body-lg"
+      >
+        Find out what’s involved for students:
+        <BaseLink
+          class="font-normal inline text-action underline hover:text-action-dark cursor-pointer"
+          :to="data.studentProject.urlPath"
+          variant="none"
+        >
+          View the Project Steps
+        </BaseLink>
+      </p>
+    </LayoutHelper>
+
+    <MetaPanel
+      button="View Standards"
+      :primary-subject="data.primarySubject"
+      :additional-subjects="data.additionalSubjects"
+      :time="data.time"
+      :grade-levels="data.gradeLevels"
+      :standards="data.standards"
+      negative-bottom
     />
 
-    <!-- hero image -->
+    <!-- hero media -->
     <HeroMedia
       v-if="
         !heroEmpty &&
@@ -96,36 +206,10 @@ export default defineComponent({
       :constrain="data.heroConstrain"
     />
 
-    <!-- news headline and author -->
-    <LayoutHelper
-      indent="col-2"
-      class="mb-10"
-    >
-      <DetailHeadline
-        :title="data.title"
-        :read-time="data.readTime"
-        :publication-date="data.publicationDate"
-        :publication-time="data.publicationTime"
-        :author="data.author"
-        label="Explainer Article"
-        pill-color="secondary"
-        schema
-        pill
-      />
-      <ShareButtonsEdu
-        v-if="data?.url"
-        class="mt-4"
-        :url="data.url"
-        :title="data.title"
-        :image="data.thumbnailImage?.original"
-      />
-    </LayoutHelper>
-
-    <!-- inline hero content -->
+    <!-- TODO: put this in a component (exclude layout though) -->
     <LayoutHelper
       v-if="!heroEmpty && heroInline"
-      indent="col-2"
-      class="lg:mb-22 mt-10 mb-10"
+      class="lg:mb-22 mb-10"
     >
       <BlockImageStandard
         v-if="data.hero[0].blockType === 'HeroImageBlock'"
@@ -161,24 +245,74 @@ export default defineComponent({
       />
     </LayoutHelper>
 
-    <!-- summary and topper -->
-    <LayoutHelper
-      indent="col-3"
-      class="lg:mb-8 mb-5"
-    >
-      <p
-        class="text-body-lg font-semibold"
-        itemprop="abstract"
-      >
-        {{ data.summary }}
-      </p>
-    </LayoutHelper>
+    <NavJumpMenu
+      ref="PageEduLessonJumpMenu"
+      :title="data.title"
+      :blocks="headingBlocks"
+      :enabled="true"
+    />
+
+    <PageEduLessonSection
+      v-if="data.overview"
+      :index="1"
+      :heading="overviewHeading"
+      :blocks="data.overview"
+      :image="data.overviewImage"
+    />
+
+    <PageEduLessonSection
+      v-if="data.materials"
+      :heading="materialsHeading"
+      :text="data.materials"
+      :image="data.materialsImage"
+    />
+
+    <PageEduLessonSection
+      v-if="data.management"
+      :index="2"
+      :heading="managementHeading"
+      :blocks="data.management"
+    />
+
+    <PageEduLessonSection
+      v-if="data.background"
+      :heading="backgroundHeading"
+      :blocks="data.background"
+    />
+
+    <PageEduLessonSection
+      v-if="data.procedures"
+      :heading="proceduresHeading"
+      :procedures="data.procedures"
+      :procedure-steps="data.proceduresStepsNumbering"
+    />
+
+    <PageEduLessonSection
+      v-if="data.discussion"
+      :heading="discussionHeading"
+      :blocks="data.discussion"
+    />
+
+    <PageEduLessonSection
+      v-if="data.assessment"
+      :heading="assessmentHeading"
+      :blocks="data.assessment"
+    />
+
+    <PageEduLessonSection
+      v-if="data.extensions"
+      :heading="extensionsHeading"
+      :blocks="data.extensions"
+    />
+
+    <PageEduLessonSection
+      v-if="data.techAddons"
+      :heading="techAddonsHeading"
+      :blocks="data.techAddons"
+    />
 
     <!-- streamfield blocks -->
-    <BlockStreamfield
-      itemprop="articleBody"
-      :data="data.body"
-    />
+    <BlockStreamfield :data="data.body" />
 
     <!-- related links -->
     <LayoutHelper

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
@@ -81,9 +81,10 @@ const heroInline = computed((): boolean => {
     if (data?.hero[0].blockType === 'VideoBlock') {
       return false
     } else if (
-      data?.heroPosition === 'inline' ||
       data?.hero[0].blockType === 'CarouselBlock' ||
-      data?.hero[0].blockType === 'VideoEmbedBlock'
+      data?.hero[0].blockType === 'IframeEmbedBlock' ||
+      data?.hero[0].blockType === 'VideoEmbedBlock' ||
+      data?.hero[0].blockType === 'ImageComparisonBlock'
     ) {
       return true
     }
@@ -233,8 +234,8 @@ const consolidatedSections = computed(() => {
         Find out what’s involved for students:
         <BaseLink
           class="font-normal inline text-action underline hover:text-action-dark cursor-pointer"
-          :to="data.studentProject.urlPath"
           variant="none"
+          :to="data.studentProject.urlPath"
         >
           View the Project Steps
         </BaseLink>
@@ -242,13 +243,13 @@ const consolidatedSections = computed(() => {
     </LayoutHelper>
     <MetaPanel
       button="View Standards"
+      theme="stars"
       :primary-subject="data.primarySubject"
       :additional-subjects="data.additionalSubjects"
       :time="data.time"
       :grade-levels="data.gradeLevels"
       :standards="data.standards"
       negative-bottom
-      theme="stars"
     />
 
     <!-- hero media -->

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
@@ -1,0 +1,200 @@
+<script lang="ts">
+import { defineComponent } from 'vue'
+import HeroMedia from './../../../components/HeroMedia/HeroMedia.vue'
+import BaseImagePlaceholder from './../../../components/BaseImagePlaceholder/BaseImagePlaceholder.vue'
+import BlockImageCarousel from './../../../components/BlockImageCarousel/BlockImageCarousel.vue'
+import BlockImageComparison from './../../../components/BlockImageComparison/BlockImageComparison.vue'
+import BlockLinkCarousel from './../../../components/BlockLinkCarousel/BlockLinkCarousel.vue'
+import LayoutHelper from './../../../components/LayoutHelper/LayoutHelper.vue'
+import DetailHeadline from './../../../components/DetailHeadline/DetailHeadline.vue'
+import BlockImageStandard from './../../../components/BlockImage/BlockImageStandard.vue'
+import ShareButtonsEdu from './../../../components/ShareButtonsEdu/ShareButtonsEdu.vue'
+import BlockStreamfield from './../../../components/BlockStreamfield/BlockStreamfield.vue'
+import BlockIframeEmbed from '../../../components/BlockIframeEmbed/BlockIframeEmbed.vue'
+import BlockRelatedLinks from '../../../components/BlockRelatedLinks/BlockRelatedLinks.vue'
+
+export default defineComponent({
+  name: 'PageEduExplainerArticle',
+  components: {
+    HeroMedia,
+    BaseImagePlaceholder,
+    LayoutHelper,
+    DetailHeadline,
+    BlockImageStandard,
+    BlockIframeEmbed,
+    ShareButtonsEdu,
+    BlockStreamfield,
+    BlockImageCarousel,
+    BlockImageComparison,
+    BlockLinkCarousel,
+    BlockRelatedLinks
+  },
+  props: {
+    data: {
+      type: Object,
+      required: false,
+      default: undefined
+    }
+  },
+  computed: {
+    heroEmpty(): boolean {
+      return (this.data?.hero || []).length === 0
+    },
+    heroInline(): boolean {
+      if (!this.heroEmpty) {
+        if (this.data?.hero[0].blockType === 'VideoBlock') {
+          return false
+        } else if (
+          this.data?.heroPosition === 'inline' ||
+          this.data?.hero[0].blockType === 'CarouselBlock' ||
+          this.data?.hero[0].blockType === 'VideoEmbedBlock'
+        ) {
+          return true
+        }
+      }
+      return false
+    },
+    computedClass(): string {
+      if (this.heroInline || this.heroEmpty) {
+        return 'pt-5 lg:pt-12'
+      } else if (!this.heroInline) {
+        return '-nav-offset'
+      }
+      return ''
+    }
+  }
+})
+</script>
+<template>
+  <div
+    v-if="data"
+    class="ThemeVariantLight"
+    :class="computedClass"
+    itemscope
+    itemtype="http://schema.org/Article"
+  >
+    <!-- schema.org -->
+    <meta
+      v-if="data.thumbnailImage && data.thumbnailImage.original"
+      itemprop="image"
+      :content="data.thumbnailImage.original"
+    />
+
+    <!-- hero image -->
+    <HeroMedia
+      v-if="
+        !heroEmpty &&
+        !heroInline &&
+        (data.hero[0].blockType === 'HeroImageBlock' || data.hero[0].blockType === 'VideoBlock')
+      "
+      class="md:mb-12 lg:mb-18 mb-10"
+      :image="data.hero[0].image"
+      :video="data.hero[0].video"
+      :display-caption="data.hero[0].displayCaption"
+      :caption="data.hero[0].caption"
+      :credit="data.hero[0].credit"
+      :constrain="data.heroConstrain"
+    />
+
+    <!-- news headline and author -->
+    <LayoutHelper
+      indent="col-2"
+      class="mb-10"
+    >
+      <DetailHeadline
+        :title="data.title"
+        :read-time="data.readTime"
+        :publication-date="data.publicationDate"
+        :publication-time="data.publicationTime"
+        :author="data.author"
+        label="Explainer Article"
+        pill-color="secondary"
+        schema
+        pill
+      />
+      <ShareButtonsEdu
+        v-if="data?.url"
+        class="mt-4"
+        :url="data.url"
+        :title="data.title"
+        :image="data.thumbnailImage?.original"
+      />
+    </LayoutHelper>
+
+    <!-- inline hero content -->
+    <LayoutHelper
+      v-if="!heroEmpty && heroInline"
+      indent="col-2"
+      class="lg:mb-22 mt-10 mb-10"
+    >
+      <BlockImageStandard
+        v-if="data.hero[0].blockType === 'HeroImageBlock'"
+        :data="data.hero[0].imageInline"
+        :display-caption="data.hero[0].displayCaption"
+        :caption="data.hero[0].caption"
+        :constrain="data.heroConstrain"
+      />
+      <BlockImageCarousel
+        v-else-if="data.hero[0].blockType === 'CarouselBlock'"
+        :items="data.hero[0].blocks"
+        :block-id="data.hero[0].id"
+      />
+      <BlockIframeEmbed
+        v-else-if="data.hero[0].blockType === 'IframeEmbedBlock'"
+        :data="data.hero[0]"
+      />
+      <BlockVideo
+        v-else-if="data.hero[0].blockType === 'VideoBlock'"
+        :data="data.hero[0]"
+        autoplay
+      />
+      <BaseImagePlaceholder
+        v-else-if="data.hero[0].blockType === 'VideoEmbedBlock'"
+        aspect-ratio="16:9"
+        dark-mode
+      >
+        <div v-html="data.hero[0].embed.embed"></div>
+      </BaseImagePlaceholder>
+      <BlockImageComparison
+        v-else-if="data.hero[0].blockType === 'ImageComparisonBlock'"
+        :data="data.hero[0]"
+      />
+    </LayoutHelper>
+
+    <!-- summary and topper -->
+    <LayoutHelper
+      indent="col-3"
+      class="lg:mb-8 mb-5"
+    >
+      <p
+        class="text-body-lg font-semibold"
+        itemprop="abstract"
+      >
+        {{ data.summary }}
+      </p>
+    </LayoutHelper>
+
+    <!-- streamfield blocks -->
+    <BlockStreamfield
+      itemprop="articleBody"
+      :data="data.body"
+    />
+
+    <!-- related links -->
+    <LayoutHelper
+      v-if="data.relatedLinks && data.relatedLinks.length"
+      indent="col-3"
+      class="lg:my-18 my-10"
+    >
+      <BlockRelatedLinks :data="data.relatedLinks[0]" />
+    </LayoutHelper>
+
+    <!-- related content -->
+    <BlockLinkCarousel
+      item-type="cards"
+      class="lg:my-24 my-12 print:px-4"
+      :heading="data.relatedContentHeading"
+      :items="data.relatedContent"
+    />
+  </div>
+</template>

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue'
-import { uniqueId } from 'lodash'
 import type {
   ImageObject,
   PageEduResourcesObject,
@@ -240,7 +239,6 @@ const consolidatedSections = computed(() => {
         </BaseLink>
       </p>
     </LayoutHelper>
-
     <MetaPanel
       button="View Standards"
       :primary-subject="data.primarySubject"

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
@@ -68,8 +68,7 @@ const stringAsHeadingBlockData = (heading) => {
   return {
     blockType: 'HeadingBlock',
     heading: heading,
-    level: 'h2',
-    id: `lesson_heading_${uniqueId()}`
+    level: 'h2'
   }
 }
 
@@ -113,7 +112,7 @@ const sectionOrder = [
   'techAddons'
 ]
 
-const sectionHeadings = computed(() => {
+const staticSectionHeadings = computed(() => {
   const result = sectionOrder.reduce((acc, section) => {
     acc[section] = stringAsHeadingBlockData(
       data[`${section}Heading`],
@@ -124,11 +123,11 @@ const sectionHeadings = computed(() => {
   return result
 })
 
-const consolidateBlocks = (sections) => {
+const consolidatedBlocks = computed(() => {
   const blocks = []
-  sections.forEach((section) => {
+  sectionOrder.forEach((section) => {
     if (data[section]) {
-      blocks.push(sectionHeadings.value[section])
+      blocks.push(staticSectionHeadings.value[section])
       if (section !== 'materials' && section !== 'procedures') {
         blocks.push(...data[section])
       } else if (section === 'procedures') {
@@ -139,15 +138,16 @@ const consolidateBlocks = (sections) => {
       }
     }
   })
+  blocks.push(...data.body)
   return blocks
-}
+})
 
 const consolidatedSections = computed(() => {
   const sections = []
   sectionOrder.forEach((section) => {
     if (data[section]) {
       sections.push({
-        heading: sectionHeadings.value[section],
+        heading: staticSectionHeadings.value[section],
         blocks: section !== 'materials' && section !== 'procedures' ? data[section] : undefined,
         text: section === 'materials' ? data[section] : undefined,
         procedures: section === 'procedures' ? data[section] : undefined,
@@ -156,10 +156,6 @@ const consolidatedSections = computed(() => {
     }
   })
   return sections
-})
-
-const consolidatedBlocks = computed(() => {
-  return consolidateBlocks(sectionOrder)
 })
 </script>
 <template>

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { computed, reactive } from 'vue'
+import { camelCase } from 'lodash'
+import type { ImageObject, StreamfieldBlockData } from './../../../interfaces'
+import BlockHeading, {
+  type BlockHeadingObject
+} from './../../../components/BlockHeading/BlockHeading.vue'
+import BaseHeading from './../../../components/BaseHeading/BaseHeading.vue'
+import BlockText from './../../../components/BlockText/BlockText.vue'
+import LayoutHelper from './../../../components/LayoutHelper/LayoutHelper.vue'
+import BlockImageStandard from './../../../components/BlockImage/BlockImageStandard.vue'
+import BlockStreamfield from './../../../components/BlockStreamfield/BlockStreamfield.vue'
+
+interface PageEduLessonSectionProps {
+  heading: BlockHeadingObject
+  blocks?: StreamfieldBlockData[]
+  procedures?: {
+    procedure: StreamfieldBlockData[]
+  }[]
+  procedureSteps?: boolean
+  text?: string
+  image?: ImageObject
+  index?: number
+}
+
+const props = withDefaults(defineProps<PageEduLessonSectionProps>(), {
+  heading: undefined,
+  blocks: undefined,
+  procedures: undefined,
+  procedureSteps: false,
+  text: undefined,
+  image: undefined,
+  index: undefined
+})
+
+const { heading, blocks, image } = reactive(props)
+
+const anchorId = computed(() => {
+  return 'lesson_' + camelCase(heading.heading)
+})
+</script>
+<template>
+  <section
+    :id="anchorId"
+    :aria-label="heading.heading"
+  >
+    <LayoutHelper
+      indent="col-3"
+      class="lg:mb-8 mb-5"
+    >
+      <BlockHeading
+        :data="heading"
+        :index="heading.index"
+        generate-id
+      />
+    </LayoutHelper>
+
+    <LayoutHelper
+      v-if="image"
+      indent="col-2"
+      class="lg:mb-8 mb-5"
+    >
+      <!-- image goes here -->
+      <BlockImageStandard :data="image" />
+    </LayoutHelper>
+
+    <BlockStreamfield
+      v-if="blocks"
+      :data="blocks"
+    />
+    <template v-else-if="procedures?.length">
+      <template
+        v-for="(item, procedure_index) in procedures"
+        :key="procedure_index"
+      >
+        <LayoutHelper
+          v-if="procedureSteps"
+          indent="col-3"
+          class="lg:mb-8 mb-5"
+        >
+          <BaseHeading level="h3">
+            {{ 'Section ' + (Number(procedure_index) + 1) }}
+          </BaseHeading>
+        </LayoutHelper>
+        <BlockStreamfield
+          v-if="item.procedure"
+          :data="item.procedure"
+        />
+      </template>
+    </template>
+    <LayoutHelper
+      v-else-if="text"
+      indent="col-3"
+      class="lg:mb-18 mb-10"
+    >
+      <BlockText :text="text" />
+    </LayoutHelper>
+  </section>
+</template>

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
@@ -28,8 +28,7 @@ const props = withDefaults(defineProps<PageEduLessonSectionProps>(), {
   procedures: undefined,
   procedureSteps: false,
   text: undefined,
-  image: undefined,
-  index: undefined
+  image: undefined
 })
 
 const { heading, blocks, image } = reactive(props)

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
@@ -20,7 +20,6 @@ interface PageEduLessonSectionProps {
   procedureSteps?: boolean
   text?: string
   image?: ImageObject
-  index?: number
 }
 
 const props = withDefaults(defineProps<PageEduLessonSectionProps>(), {
@@ -50,7 +49,6 @@ const anchorId = computed(() => {
     >
       <BlockHeading
         :data="heading"
-        :index="heading.index"
         generate-id
       />
     </LayoutHelper>
@@ -70,8 +68,8 @@ const anchorId = computed(() => {
     />
     <template v-else-if="procedures?.length">
       <template
-        v-for="(item, procedure_index) in procedures"
-        :key="procedure_index"
+        v-for="(item, index) in procedures"
+        :key="index"
       >
         <LayoutHelper
           v-if="procedureSteps"
@@ -79,7 +77,7 @@ const anchorId = computed(() => {
           class="lg:mb-8 mb-5"
         >
           <BaseHeading level="h3">
-            {{ 'Section ' + (Number(procedure_index) + 1) }}
+            {{ 'Section ' + (Number(index) + 1) }}
           </BaseHeading>
         </LayoutHelper>
         <BlockStreamfield

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
@@ -11,11 +11,13 @@ import LayoutHelper from './../../../components/LayoutHelper/LayoutHelper.vue'
 import BlockImageStandard from './../../../components/BlockImage/BlockImageStandard.vue'
 import BlockStreamfield from './../../../components/BlockStreamfield/BlockStreamfield.vue'
 
-interface PageEduLessonSectionProps {
+export interface PageEduLessonSectionProps {
   heading: BlockHeadingObject
   blocks?: StreamfieldBlockData[]
   procedures?: {
-    procedure: StreamfieldBlockData[]
+    procedure: {
+      blocks: StreamfieldBlockData[]
+    }
   }[]
   procedureSteps?: boolean
   text?: string
@@ -80,8 +82,8 @@ const anchorId = computed(() => {
           </BaseHeading>
         </LayoutHelper>
         <BlockStreamfield
-          v-if="item?.procedure"
-          :data="item.procedure"
+          v-if="item?.procedure?.blocks"
+          :data="item.procedure.blocks"
         />
       </template>
     </template>

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
@@ -80,7 +80,7 @@ const anchorId = computed(() => {
           </BaseHeading>
         </LayoutHelper>
         <BlockStreamfield
-          v-if="item.procedure"
+          v-if="item?.procedure"
           :data="item.procedure"
         />
       </template>

--- a/packages/vue/src/templates/edu/PageEduNewsDetail/PageEduNewsDetail.stories.js
+++ b/packages/vue/src/templates/edu/PageEduNewsDetail/PageEduNewsDetail.stories.js
@@ -56,6 +56,7 @@ export const BaseStory = {
       heroPosition: 'full_bleed',
       heroImage: HeroMediaData.image,
       heroImageInline: HeroMediaData.imageInline,
+      showJumpMenu: true,
       ...BlockStreamfieldData
     }
   }

--- a/packages/vue/src/templates/edu/PageEduNewsDetail/PageEduNewsDetail.vue
+++ b/packages/vue/src/templates/edu/PageEduNewsDetail/PageEduNewsDetail.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, defineExpose } from 'vue'
 import isEmpty from 'lodash/isEmpty.js'
-import type { StreamfieldBlockData } from './../../../components/BlockStreamfield/BlockStreamfield.vue'
+import type { StreamfieldBlockData } from './../../../interfaces'
 import type {
   AuthorObject,
   ImageObject,

--- a/packages/vue/src/templates/edu/PageEduNewsDetail/PageEduNewsDetail.vue
+++ b/packages/vue/src/templates/edu/PageEduNewsDetail/PageEduNewsDetail.vue
@@ -1,15 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, defineExpose } from 'vue'
 import isEmpty from 'lodash/isEmpty.js'
-import type { StreamfieldBlockData } from './../../../interfaces'
-import type {
-  AuthorObject,
-  ImageObject,
-  PageObject,
-  RelatedLinkObject,
-  Topic,
-  ThumbnailObject
-} from './../../../interfaces'
+import type { AuthorObject, ImageObject, PageObject } from './../../../interfaces'
 import HeroMedia from './../../../components/HeroMedia/HeroMedia.vue'
 import LayoutHelper from './../../../components/LayoutHelper/LayoutHelper.vue'
 import DetailHeadline from './../../../components/DetailHeadline/DetailHeadline.vue'
@@ -60,7 +52,7 @@ const computedClass = computed(() => {
 })
 
 const dateTimeArray = computed(() => {
-  return props.data.publicationDate.split(' ')
+  return props.data.publicationDate ? props.data.publicationDate.split(' ') : undefined
 })
 
 defineExpose({

--- a/packages/vue/src/templates/edu/PageEduNewsDetail/PageEduNewsDetail.vue
+++ b/packages/vue/src/templates/edu/PageEduNewsDetail/PageEduNewsDetail.vue
@@ -79,7 +79,7 @@ defineExpose({
       ref="PageEduNewsDetailJumpMenu"
       :title="data.title"
       :blocks="data.body"
-      :enabled="true"
+      :enabled="data.showJumpMenu"
     />
 
     <!-- schema.org -->

--- a/packages/vue/src/templates/edu/PageEduNewsDetail/PageEduNewsDetail.vue
+++ b/packages/vue/src/templates/edu/PageEduNewsDetail/PageEduNewsDetail.vue
@@ -5,7 +5,7 @@ import type { StreamfieldBlockData } from './../../../interfaces'
 import type {
   AuthorObject,
   ImageObject,
-  PageResponseObject,
+  PageObject,
   RelatedLinkObject,
   Topic,
   ThumbnailObject
@@ -19,23 +19,14 @@ import BlockText from './../../../components/BlockText/BlockText.vue'
 import BlockStreamfield from './../../../components/BlockStreamfield/BlockStreamfield.vue'
 import NavJumpMenu from './../../../components/NavJumpMenu/NavJumpMenu.vue'
 
-interface PageEduNewsDetailObject extends PageResponseObject {
+interface PageEduNewsDetailObject extends PageObject {
   readTime: string
   url: string
   heroImage: ImageObject
   heroImageInline: ImageObject
-  thumbnailImage: ThumbnailObject
-  heroPosition: string
   heroConstrain: boolean
   heroImageCaption: string
   authors: AuthorObject[]
-  publicationDate: string
-  title: string
-  getTopicsForDisplay: Topic[]
-  summary: string
-  topper: string
-  relatedLinks: RelatedLinkObject[]
-  body: StreamfieldBlockData[]
   showJumpMenu: boolean
 }
 

--- a/packages/vue/src/utils/getHeadingId.ts
+++ b/packages/vue/src/utils/getHeadingId.ts
@@ -1,5 +1,5 @@
 import { camelCase } from 'lodash'
 
 export const getHeadingId = (heading: string, index?: number) => {
-  return camelCase(heading + (index ? index : ''))
+  return camelCase('anchor_' + heading + (index ? index : ''))
 }

--- a/packages/vue/src/utils/getHeadingId.ts
+++ b/packages/vue/src/utils/getHeadingId.ts
@@ -1,5 +1,5 @@
 import { camelCase } from 'lodash'
-
-export const getHeadingId = (heading: string, blockId?: string) => {
+import { type HeadingLevel } from '../components/BaseHeading/BaseHeading.vue'
+export const getHeadingId = (heading: HeadingLevel, blockId?: string) => {
   return 'anchor_' + camelCase(heading) + (blockId ? '_' + camelCase(blockId) : '')
 }

--- a/packages/vue/src/utils/getHeadingId.ts
+++ b/packages/vue/src/utils/getHeadingId.ts
@@ -1,6 +1,5 @@
 import { camelCase } from 'lodash'
 
-export const getHeadingId = (heading: string, id?: string) => {
-  return 'anchor_' + camelCase(heading) + id ? '_' + camelCase(id) : ''
-  // return camelCase('anchor_' + heading)
+export const getHeadingId = (heading: string, blockId?: string) => {
+  return 'anchor_' + camelCase(heading) + (blockId ? '_' + camelCase(blockId) : '')
 }

--- a/packages/vue/src/utils/getHeadingId.ts
+++ b/packages/vue/src/utils/getHeadingId.ts
@@ -1,5 +1,6 @@
 import { camelCase } from 'lodash'
 
-export const getHeadingId = (heading: string, index?: number) => {
-  return camelCase('anchor_' + heading + (index ? index : ''))
+export const getHeadingId = (heading: string, id?: string) => {
+  return 'anchor_' + camelCase(heading) + id ? '_' + camelCase(id) : ''
+  // return camelCase('anchor_' + heading)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       vue:
         specifier: ^3.2.47
         version: 3.4.27(typescript@5.4.5)
+      vue-bind-once:
+        specifier: ^0.2.1
+        version: 0.2.1(vue@3.4.27(typescript@5.4.5))
       vue3-compare-image:
         specifier: ^1.2.5
         version: 1.2.5(vue@3.4.27(typescript@5.4.5))
@@ -533,6 +536,9 @@ importers:
       vue:
         specifier: ^3.4.21
         version: 3.4.27(typescript@5.4.5)
+      vue-bind-once:
+        specifier: ^0.2.1
+        version: 0.2.1(vue@3.4.27(typescript@5.4.5))
       vue-observe-visibility:
         specifier: ^1.0.0
         version: 1.0.0
@@ -8938,6 +8944,11 @@ packages:
 
   vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
+
+  vue-bind-once@0.2.1:
+    resolution: {integrity: sha512-17toDsxK7hc8folglp6TYtybi/Q0FVJal6plFeMeofWd2nOl4axHg9ckR/5ORNCj+GyjMAWh/OD10MvT6AXbHA==}
+    peerDependencies:
+      vue: ^3
 
   vue-bundle-renderer@2.1.0:
     resolution: {integrity: sha512-uZ+5ZJdZ/b43gMblWtcpikY6spJd0nERaM/1RtgioXNfWFbjKlUwrS8HlrddN6T2xtptmOouWclxLUkpgcVX3Q==}
@@ -19726,6 +19737,11 @@ snapshots:
       vscode-languageserver-protocol: 3.16.0
 
   vscode-uri@3.0.8: {}
+
+  vue-bind-once@0.2.1(vue@3.4.27(typescript@5.4.5)):
+    dependencies:
+      scule: 1.3.0
+      vue: 3.4.27(typescript@5.4.5)
 
   vue-bundle-renderer@2.1.0:
     dependencies:


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Supports:

- https://github.com/nasa-jpl/www/issues/190
- https://github.com/nasa-jpl/www/issues/379
- https://github.com/nasa-jpl/www/issues/99
- https://github.com/nasa-jpl/www/issues/284
- Part of https://github.com/nasa-jpl/www/issues/364

This PR:

- Adds BaseAccordionItem and BlockAccordion FE components (BaseAccordionItem was needed for MetaPanel)
- Adds MetaPanel component (uses basis of BlockAccordion)
- Adds EduLessonPage template component
- Adjustments to NavJumpMenu and NavSecondary (now tested with live data)
- Modifies HeroMedia for EDU to hide both the caption and credit if "display caption" is unchecked
- Adds package [vue-bind-once](https://github.com/danielroe/vue-bind-once), as we needed an SSR friendly way to generate ids (used for aria tags)

## Instructions to test

<!-- Provide instructions on how a reviewer can verify your work. -->

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [x] Firefox
- [ ] Safari
- [ ] Edge
