### PR TITLE
fix: BlockLinkCard metadata tweaks

### DIFF
--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
@@ -152,6 +152,31 @@ export const EventItemWithChip = {
     }
   }
 }
+export const EduLesson = {
+  decorators: [
+    () => ({
+      template: `<div id="storyDecorator" class="relative grid grid-cols-2 gap-3"><story/></div>`
+    })
+  ],
+  args: {
+    ...BlockLinkCardData,
+    data: {
+      page: {
+        __typename: 'EDULessonPage',
+        ...BlockLinkCardData.data,
+        primarySubject: {
+          subject: 'Math'
+        },
+        gradeLevels: [
+          { gradeLevel: 'K' },
+          { gradeLevel: '1' },
+          { gradeLevel: '2' },
+          { gradeLevel: '8' }
+        ]
+      }
+    }
+  }
+}
 export const EduExplainerArticle = {
   decorators: [
     () => ({

--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
@@ -129,6 +129,29 @@ export const EventItem = {
     }
   }
 }
+export const EventItemWithChip = {
+  decorators: [
+    () => ({
+      template: `<div id="storyDecorator" class="relative grid grid-cols-2 gap-3"><story/></div>`
+    })
+  ],
+  args: {
+    ...BlockLinkCardData,
+    showCalendarChip: true,
+    data: {
+      page: {
+        ...BlockLinkCardData.data,
+        __typename: 'EDUEventPage',
+        startDate: '2021-11-11',
+        startDatetime: '2021-11-11T00:00:00-08:00',
+        endDatetime: '2021-11-11T23:59:59.999999-08:00',
+        endDate: '2021-11-11',
+        ongoing: false,
+        eventType: 'Workshop'
+      }
+    }
+  }
+}
 export const EduExplainerArticle = {
   decorators: [
     () => ({

--- a/packages/vue/src/components/MetadataEvent/MetadataEvent.vue
+++ b/packages/vue/src/components/MetadataEvent/MetadataEvent.vue
@@ -13,13 +13,17 @@ interface MetadataEventProps {
   event: EventCardObject
   compact?: boolean
   allowBreak?: boolean
+  showLocation?: boolean
+  showTime?: boolean
 }
 
 // define props
 const props = withDefaults(defineProps<MetadataEventProps>(), {
   event: undefined,
   compact: false,
-  allowBreak: false
+  allowBreak: false,
+  showLocation: true,
+  showTime: true
 })
 
 const startDatetimeForFormatting = computed(() => {
@@ -71,60 +75,62 @@ const locationName = computed(() => {
       }}</span>
     </div>
     <div
-      v-show="displayTime"
+      v-show="displayTime && showTime"
       class="MetadataEventItem"
     >
       <IconTime class="MetadataEventIcon text-[1.15em]" />
       <span>{{ displayTime }}</span>
     </div>
     <!--Virtual location -->
-    <div
-      v-if="props.event.isVirtualEvent && props.event.locationLink && !props.compact"
-      itemprop="location"
-      itemscope
-      itemtype="https://schema.org/VirtualLocation"
-      class="MetadataEventItem"
-    >
-      <link
-        itemprop="url"
-        :href="props.event.locationLink"
-      />
-      <meta
-        itemprop="name"
-        :content="locationName"
-      />
-      <IconLocation class="MetadataEventIcon text-[1.1em]" />
-      <BaseLink
-        variant="none"
-        class="text-action"
-        :href="props.event.locationLink"
-        external-target-blank
-      >
-        {{ locationName }}
-      </BaseLink>
-    </div>
-    <!-- Normal location -->
-    <div
-      v-else-if="locationName"
-      class="MetadataEventItem"
-    >
-      <meta
-        v-if="!props.compact"
+    <template v-if="showLocation">
+      <div
+        v-if="props.event.isVirtualEvent && props.event.locationLink && !props.compact"
         itemprop="location"
-        :content="locationName"
-      />
-      <IconLocation class="MetadataEventIcon text-[1.2em]" />
-      <BaseLink
-        v-if="props.event.locationLink && !props.compact"
-        variant="none"
-        class="text-action"
-        :href="props.event.locationLink"
-        external-target-blank
+        itemscope
+        itemtype="https://schema.org/VirtualLocation"
+        class="MetadataEventItem"
       >
-        {{ locationName }}
-      </BaseLink>
-      <span v-else>{{ locationName }}</span>
-    </div>
+        <link
+          itemprop="url"
+          :href="props.event.locationLink"
+        />
+        <meta
+          itemprop="name"
+          :content="locationName"
+        />
+        <IconLocation class="MetadataEventIcon text-[1.1em]" />
+        <BaseLink
+          variant="none"
+          class="text-action"
+          :href="props.event.locationLink"
+          external-target-blank
+        >
+          {{ locationName }}
+        </BaseLink>
+      </div>
+      <!-- Normal location -->
+      <div
+        v-else-if="locationName"
+        class="MetadataEventItem"
+      >
+        <meta
+          v-if="!props.compact"
+          itemprop="location"
+          :content="locationName"
+        />
+        <IconLocation class="MetadataEventIcon text-[1.2em]" />
+        <BaseLink
+          v-if="props.event.locationLink && !props.compact"
+          variant="none"
+          class="text-action"
+          :href="props.event.locationLink"
+          external-target-blank
+        >
+          {{ locationName }}
+        </BaseLink>
+        <span v-else>{{ locationName }}</span>
+      </div>
+    </template>
   </div>
 </template>
 <style lang="scss">

--- a/packages/vue/src/constants.ts
+++ b/packages/vue/src/constants.ts
@@ -3,10 +3,17 @@ import type { DictionaryInterface, PillDictionaryInterface } from './interfaces'
 export const eduMetadataDictionary: PillDictionaryInterface = {
   EDUExplainerArticlePage: {
     label: 'Explainer Article',
-    variant: 'secondary'
+    variant: 'secondary',
+    type: 'resource'
+  },
+  EDULessonPage: {
+    label: 'Lesson',
+    variant: 'primary',
+    type: 'resource'
   },
   EDUEventPage: {
-    variant: 'primary'
+    variant: 'primary',
+    type: 'event'
   }
 }
 
@@ -16,5 +23,6 @@ export const searchContentTypeToPageType: DictionaryInterface = {
   events_eventpage: 'EventPage',
   missions_mission: 'Mission',
   eduevents_edueventpage: 'EDUEventPage',
-  eduresources_eduexplainerarticlepage: 'EDUExplainerArticlePage'
+  eduresources_eduexplainerarticlepage: 'EDUExplainerArticlePage',
+  eduresources_edulessonpage: 'EDULessonPage'
 }

--- a/packages/vue/src/interfaces.ts
+++ b/packages/vue/src/interfaces.ts
@@ -103,6 +103,9 @@ export interface FormOption {
 export interface Card {
   __typename?: string
   type?: string
+  parent?: {
+    title: string
+  }
   url?: string
   externalLink?: string
   page?: Card | EventCardObject | EduResourceCardObject
@@ -192,6 +195,7 @@ export type MetadataType = 'event' | 'resource'
 export interface LabelObject {
   label?: string
   variant: string
+  type?: MetadataType
 }
 export interface PillDictionaryInterface {
   [EDUExplainerArticlePage: string]: LabelObject

--- a/packages/vue/src/templates/PageContent/PageContent.vue
+++ b/packages/vue/src/templates/PageContent/PageContent.vue
@@ -43,6 +43,11 @@ export default defineComponent({
   },
   computed: {
     ...mapStores(useThemeStore),
+    displayLabel() {
+      return this.themeStore.isEdu && this.data?.parent?.title && this.data?.parent?.title !== 'EDU'
+        ? this.data?.parent?.title
+        : this.data?.displayLabel
+    },
     heroInline() {
       if (this.data?.heroPosition === 'inline') {
         return true
@@ -94,7 +99,7 @@ export default defineComponent({
     >
       <DetailHeadline
         :title="data.title"
-        :label="data.displayLabel"
+        :label="displayLabel"
         :class="{ 'sr-only': hideH1 }"
       />
       <ShareButtonsEdu

--- a/packages/vue/src/templates/edu/PageContentEdu.stories.js
+++ b/packages/vue/src/templates/edu/PageContentEdu.stories.js
@@ -28,6 +28,6 @@ export default {
 export const BaseStory = {
   name: 'PageContent',
   args: {
-    data: ContentPageData
+    data: { ...ContentPageData, displayLabel: undefined, parent: { title: 'Parent Page' } }
   }
 }

--- a/packages/vue/src/utils/rangeifyGrades.ts
+++ b/packages/vue/src/utils/rangeifyGrades.ts
@@ -63,7 +63,7 @@ export const rangeifyGrades = (gradeLevels: GradeLevelsObject[]) => {
     const filteredGrades = rangeify(gradesArray.filter(Number.isFinite))
     let preparedGrades: string = ''
     if (filteredGrades?.length) {
-      const gradeString = filteredGrades.length > 1 ? 'Grades: ' : 'Grade: '
+      const gradeString = 'Grades: '
       preparedGrades = filteredGrades
         .map((grade, index) => (index === 0 ? gradeString + grade : grade))
         .join(', ')


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Address feedback in https://github.com/nasa-jpl/www/issues/191#issuecomment-2290272434

- removes CalendarChip from Events in BlockLinkCard
- adds metadata for EDULessonPage

## Instructions to test

1. `make vue-storybook`
2. View BlockLinkCard stories: http://localhost:6006/?path=/story/components-cards-blocklinkcard--base-story&globals=theme:ThemeEdu

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
