### PR TITLE
moving BaseTimer dayjs config to main dayjs config

### DIFF
--- a/packages/vue/src/components/BaseTimer/BaseTimer.vue
+++ b/packages/vue/src/components/BaseTimer/BaseTimer.vue
@@ -52,11 +52,7 @@
 import type { PropType } from 'vue'
 import { defineComponent } from 'vue'
 import dayjs, { type Dayjs } from 'dayjs'
-import duration, { type Duration } from 'dayjs/plugin/duration.js'
-import minMax from 'dayjs/plugin/minMax.js'
-
-dayjs.extend(duration)
-dayjs.extend(minMax)
+import { type Duration } from 'dayjs/plugin/duration.js'
 
 const calculateDuration = (start: Dayjs): Duration | undefined => {
   // Use round seconds so the datetime string stays valid and can be read by screen readers.

--- a/packages/vue/src/utils/dayjs.js
+++ b/packages/vue/src/utils/dayjs.js
@@ -3,7 +3,8 @@ import updateLocale from 'dayjs/plugin/updateLocale.js'
 import localizedFormat from 'dayjs/plugin/localizedFormat.js'
 import timezone from 'dayjs/plugin/timezone.js'
 import advancedFormat from 'dayjs/plugin/advancedFormat.js'
-
+import duration from 'dayjs/plugin/duration.js'
+import minMax from 'dayjs/plugin/minMax.js'
 // Locales must be imported manually
 // see https://github.com/iamkun/dayjs/tree/dev/src/locale
 import 'dayjs/locale/en-gb.js'
@@ -28,5 +29,8 @@ dayjs.updateLocale('en', {
     'Dec.'
   ]
 })
+
+dayjs.extend(duration)
+dayjs.extend(minMax)
 
 export default dayjs


### PR DESCRIPTION
Started getting the below error persisting on www:

```
SyntaxError: The requested module '/_nuxt/node_modules/dayjs/plugin/advancedFormat.js?v=dac44595' does not provide an export named 'default' (at dayjs.js?v=dac44595:5:8)
```

This PR fixes it, but I've only been able to test locally.