### PR TITLE
adding math text styles, using primary color for BlockText lists

### DIFF
--- a/packages/common/src/scss/_typography.scss
+++ b/packages/common/src/scss/_typography.scss
@@ -266,6 +266,11 @@
     }
   }
 
+  .math-text {
+    @apply font-serif;
+    @apply italic;
+  }
+
   // text readability class
   // use this in areas where text is overlaying an image
   // managed separately for the navigation since we can't @apply these classes there

--- a/packages/common/src/scss/components/_BlockText.scss
+++ b/packages/common/src/scss/components/_BlockText.scss
@@ -86,14 +86,10 @@
         content: '';
         width: 30px;
         height: 2px;
-        @apply bg-jpl-red block absolute top-0 left-0 mt-3;
+        @apply bg-primary block absolute top-0 left-0 mt-3;
 
         @screen sm {
           @apply mt-4;
-        }
-
-        .ThemeVariantDark & {
-          @apply bg-jpl-red-light;
         }
       }
     }

--- a/packages/common/tailwind.config.ts
+++ b/packages/common/tailwind.config.ts
@@ -62,7 +62,18 @@ const defaultTheme: Partial<CustomThemeConfig> = {
   colors: themeColors,
   fontFamily: {
     primary: ['Metropolis', ...fallbackFontStack],
-    secondary: ['Archivo Narrow', 'Metropolis', ...fallbackFontStack]
+    secondary: ['Archivo Narrow', 'Metropolis', ...fallbackFontStack],
+    serif: ['ui-serif', 'Georgia', 'Cambria', 'Times New Roman', 'Times', 'serif'],
+    mono: [
+      'ui-monospace',
+      'SFMono-Regular',
+      'Menlo',
+      'Monaco',
+      'Consolas',
+      'Liberation Mono',
+      'Courier New',
+      'monospace'
+    ]
   },
   fontWeight: {
     // Commenting out anything Tailwind provides by default but we don’t use for this project.

--- a/packages/common/tailwind.config.ts
+++ b/packages/common/tailwind.config.ts
@@ -63,17 +63,7 @@ const defaultTheme: Partial<CustomThemeConfig> = {
   fontFamily: {
     primary: ['Metropolis', ...fallbackFontStack],
     secondary: ['Archivo Narrow', 'Metropolis', ...fallbackFontStack],
-    serif: ['ui-serif', 'Georgia', 'Cambria', 'Times New Roman', 'Times', 'serif'],
-    mono: [
-      'ui-monospace',
-      'SFMono-Regular',
-      'Menlo',
-      'Monaco',
-      'Consolas',
-      'Liberation Mono',
-      'Courier New',
-      'monospace'
-    ]
+    serif: ['ui-serif', 'Georgia', 'Cambria', 'Times New Roman', 'Times', 'serif']
   },
   fontWeight: {
     // Commenting out anything Tailwind provides by default but we don’t use for this project.

--- a/packages/vue/src/docs/foundation/typography.stories.js
+++ b/packages/vue/src/docs/foundation/typography.stories.js
@@ -78,6 +78,8 @@ export const TextStyles = {
   <code>.text-body-xs</code>
   <p class="mt-8"><mark>Highlighted text</mark></p>
   <code>mark</code>
+  <p class="mt-8"><span class="math-text">This is math text. a<sup>2</sup> + a<sub>b</sub> = c</span></p>
+  <code>.math-text</code>
 </div>`
   })
 }


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses https://github.com/nasa-jpl/www/issues/286 and https://github.com/nasa-jpl/www/issues/387

## Instructions to test

1. `make vue-storybook`
2. math text can be seen at the bottom of this story: http://localhost:6006/?path=/story/foundations-typography--text-styles

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
