### PR TITLE
Proof of concept: CSS solution to continuous ordered lists in EDU Lesson Procedures

### DIFF
--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
@@ -40,6 +40,7 @@ const anchorId = computed(() => {
 <template>
   <section
     :id="anchorId"
+    class="PageEduLessonSection"
     :aria-label="heading.heading"
   >
     <LayoutHelper
@@ -79,10 +80,12 @@ const anchorId = computed(() => {
             {{ 'Section ' + (Number(index) + 1) }}
           </BaseHeading>
         </LayoutHelper>
-        <BlockStreamfield
-          v-if="item?.blocks"
-          :data="item.blocks"
-        />
+        <div class="PageEduProcedureSection">
+          <BlockStreamfield
+            v-if="item?.blocks"
+            :data="item.blocks"
+          />
+        </div>
       </template>
     </template>
     <LayoutHelper
@@ -94,3 +97,27 @@ const anchorId = computed(() => {
     </LayoutHelper>
   </section>
 </template>
+<style lang="scss">
+.PageEduProcedureSection {
+  counter-reset: listitem;
+  .BlockText ol {
+    list-style-type: none;
+    counter-reset: nestedlistitem;
+    > li {
+      counter-increment: listitem;
+      &::marker {
+        content: counter(listitem) '. ';
+      }
+    }
+    ol {
+      list-style-type: none;
+      > li {
+        counter-increment: nestedlistitem;
+        &::marker {
+          content: counter(nestedlistitem) '. ';
+        }
+      }
+    }
+  }
+}
+</style>


### PR DESCRIPTION

### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Implements the CSS solution mentioned in https://github.com/nasa-jpl/www/issues/413

![image](https://github.com/user-attachments/assets/5de019b1-99e9-4ab8-bbf7-b379072474a1)

## Instructions to test

<!-- Provide instructions on how a reviewer can verify your work. -->

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
