### PR TITLE
fixing alignment of BlockCardGrid in streamfields

### DIFF
--- a/packages/vue/src/components/BlockCardGrid/BlockCardGrid.vue
+++ b/packages/vue/src/components/BlockCardGrid/BlockCardGrid.vue
@@ -18,7 +18,7 @@
       />
     </div>
     <MixinCarousel
-      class="md:hidden sm:-ml-10 py-14 lg:py-10 -mt-10 overflow-x-hidden"
+      class="md:hidden py-14 lg:py-10 -mt-10 overflow-x-hidden"
       indent="col-1"
       :slides-per-view="3"
       no-links

--- a/packages/vue/src/components/BlockStreamfield/BlockStreamfield.vue
+++ b/packages/vue/src/components/BlockStreamfield/BlockStreamfield.vue
@@ -202,9 +202,11 @@
       <div
         v-else-if="block.blockType == 'ListBlock' && block.field === 'card_grid'"
         :key="`cardGridBlock${index}`"
-        class="lg:mb-18 mb-10"
+        class="LayoutHelper md:BaseGrid md:container md:mx-auto lg:mb-18 mb-10"
       >
-        <BlockCardGrid :cards="block.items" />
+        <div class="lg:col-start-2 lg:col-end-12 md:col-span-full md:px-4 px-0 relative">
+          <BlockCardGrid :cards="block.items" />
+        </div>
       </div>
 
       <div

--- a/packages/vue/src/templates/www/PageRoboticsDetail/PageRoboticsDetail.vue
+++ b/packages/vue/src/templates/www/PageRoboticsDetail/PageRoboticsDetail.vue
@@ -38,7 +38,7 @@
       <!-- facts -->
       <BlockCardGrid
         v-if="data.facts"
-        class="3xl:col-end-13 xl:col-end-11 md:px-4 lg:px-0 relative col-start-2 col-end-13 px-0 mt-12"
+        class="3xl:col-end-13 xl:col-end-11 md:px-4 lg:px-0 relative sm:col-start-2 sm:col-end-13 px-0 mt-12"
         :cards="data.facts"
       />
     </div>


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses feedback from https://github.com/nasa-jpl/www/issues/225#issuecomment-2305450019

## Instructions to test

1. `make vue-storybook`
2. View the `BlockStreamfield` story. `BlockCardGrid` is all the way at the bottom. Try different viewports.

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
