### PR TITLE
fix: ICS for events with no time

### DIFF
--- a/packages/vue/src/components/CalendarButton/CalendarButton.vue
+++ b/packages/vue/src/components/CalendarButton/CalendarButton.vue
@@ -81,16 +81,11 @@ export default defineComponent({
       let recurrence = undefined
       if ((this.isAllDay && this.endDatetime) || (this.startDate && this.endDatetime)) {
         // Calculate how many full days
-        console.log(this.isAllDay, this.endDatetime, this.startDate, this.endDatetime)
-        // console.log(this.startDate ? dayjs(this.startDate).tz('America/Los_Angeles') : undefined)
         const startDateDayjs = this.startDatetime
           ? dayjs(this.startDatetime)
           : dayjs(this.startDate).tz('America/Los_Angeles')
         const endDateDayjs = dayjs(this.endDatetime)
         const difference = endDateDayjs.diff(startDateDayjs, 'day') + 1
-        console.log(startDateDayjs.format())
-        console.log(endDateDayjs.format())
-        console.log(difference)
         recurrence = { frequency: 'DAILY', interval: 1, count: difference }
       }
 

--- a/packages/vue/src/components/CalendarButton/CalendarButton.vue
+++ b/packages/vue/src/components/CalendarButton/CalendarButton.vue
@@ -93,7 +93,6 @@ export default defineComponent({
         title: this.title ? this.title : undefined,
         location: this.location ? this.location : undefined,
         description: this.icsDescription,
-        // start: new Date(dayjs(this.startDate).tz('America/Los_Angeles')),
         start: this.startDatetime
           ? // @ts-ignore
             new Date(dayjs(this.startDatetime))

--- a/packages/vue/src/components/CalendarButton/CalendarButton.vue
+++ b/packages/vue/src/components/CalendarButton/CalendarButton.vue
@@ -80,13 +80,17 @@ export default defineComponent({
     init() {
       let recurrence = undefined
       if ((this.isAllDay && this.endDatetime) || (this.startDate && this.endDatetime)) {
-        console.log('initing')
         // Calculate how many full days
+        console.log(this.isAllDay, this.endDatetime, this.startDate, this.endDatetime)
+        // console.log(this.startDate ? dayjs(this.startDate).tz('America/Los_Angeles') : undefined)
         const startDateDayjs = this.startDatetime
           ? dayjs(this.startDatetime)
-          : dayjs(this.startDate)
+          : dayjs(this.startDate).tz('America/Los_Angeles')
         const endDateDayjs = dayjs(this.endDatetime)
         const difference = endDateDayjs.diff(startDateDayjs, 'day') + 1
+        console.log(startDateDayjs.format())
+        console.log(endDateDayjs.format())
+        console.log(difference)
         recurrence = { frequency: 'DAILY', interval: 1, count: difference }
       }
 
@@ -94,10 +98,13 @@ export default defineComponent({
         title: this.title ? this.title : undefined,
         location: this.location ? this.location : undefined,
         description: this.icsDescription,
+        // start: new Date(dayjs(this.startDate).tz('America/Los_Angeles')),
         start: this.startDatetime
-          ? new Date(this.startDatetime)
+          ? // @ts-ignore
+            new Date(dayjs(this.startDatetime))
           : this.startDate
-            ? new Date(this.startDate)
+            ? // @ts-ignore
+              new Date(dayjs(this.startDate).tz('America/Los_Angeles'))
             : new Date(),
         end: !this.isAllDay && this.endDatetime ? new Date(this.endDatetime) : undefined,
         recurrence

--- a/packages/vue/src/utils/dayjs.js
+++ b/packages/vue/src/utils/dayjs.js
@@ -2,6 +2,7 @@ import dayjs from 'dayjs'
 import updateLocale from 'dayjs/plugin/updateLocale.js'
 import localizedFormat from 'dayjs/plugin/localizedFormat.js'
 import timezone from 'dayjs/plugin/timezone.js'
+import utc from 'dayjs/plugin/utc.js'
 import advancedFormat from 'dayjs/plugin/advancedFormat.js'
 import duration from 'dayjs/plugin/duration.js'
 import minMax from 'dayjs/plugin/minMax.js'
@@ -10,6 +11,7 @@ import minMax from 'dayjs/plugin/minMax.js'
 import 'dayjs/locale/en-gb.js'
 
 dayjs.extend(timezone)
+dayjs.extend(utc)
 dayjs.extend(advancedFormat)
 dayjs.extend(localizedFormat)
 dayjs.extend(updateLocale)


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Address feedback in https://github.com/nasa-jpl/www/issues/319#issuecomment-2299936254

Approach: I didn't hide the button for events with no time. Instead, I fixed the start and end time generated in the ICS for those events. It will set the time from 12 am to 11:59 pm. I wasn't able to get the ICS to set "All day" without unpredictable results elsewhere.

## Instructions to test


## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
