### PR TITLE
nav: fixing active section logic, fixing global nav breadcrumbs interfering with JumpNav

### DIFF
--- a/packages/vue/src/components/NavDesktop/NavDesktop.vue
+++ b/packages/vue/src/components/NavDesktop/NavDesktop.vue
@@ -246,14 +246,17 @@ export default defineComponent({
     // to determine active class on menu links and 'more' menu links
     checkActive(item: LinkObject) {
       const urlKey = this.getUrlKey(item)
-      if (urlKey && this.breadcrumb && this.breadcrumb.menu_links) {
+      if (urlKey && this.breadcrumb?.menu_links) {
         // key into the breadcrumbs for each section
-        const objArray = this.breadcrumb.menu_links[urlKey]
+        const sectionLinks = this.breadcrumb.menu_links[urlKey]
         // check if any of the paths contained in the array are active
-        const isActive = objArray.some((el: BreadcrumbPathObject) => mixinIsActivePath(el.path))
+        const isActive = sectionLinks.some((link: BreadcrumbPathObject) =>
+          mixinIsActivePath(link.path)
+        )
         if (isActive) {
-          mixinUpdateGlobalChildren(this.breadcrumb.menu_links[urlKey])
+          mixinUpdateGlobalChildren(sectionLinks)
         }
+        console.log(isActive)
         return isActive
       }
       return false

--- a/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
+++ b/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
@@ -5,6 +5,7 @@
     ref="NavJumpMenuRef"
     class="NavJumpMenu -hide-until-threshold"
     :invert="invert"
+    jump-menu
   >
     <template v-for="(item, index) in theBreadcrumbs">
       <template v-if="item.children && item.children.length > 0">

--- a/packages/vue/src/components/NavSecondary/NavSecondary.vue
+++ b/packages/vue/src/components/NavSecondary/NavSecondary.vue
@@ -79,6 +79,10 @@ export default defineComponent({
       type: Boolean,
       required: false,
       default: false
+    },
+    jumpMenu: {
+      type: Boolean,
+      default: false
     }
   },
   data(): {
@@ -101,9 +105,12 @@ export default defineComponent({
       if (this.breadcrumb) {
         // we also want to update the store to override secondary nav
         mixinUpdateSecondary(JSON.parse(this.breadcrumb))
+
         return JSON.parse(this.breadcrumb)
       } else if (this.headerStore) {
-        return this.headerStore.globalChildren
+        if (!this.jumpMenu) {
+          return this.headerStore.globalChildren
+        }
       }
       return undefined
     },
@@ -117,7 +124,9 @@ export default defineComponent({
   mounted() {
     if (this.enabled) {
       // if there is a secondary nav displayed, then don't highlight the primary active item
-      mixinHighlightPrimary(false)
+      if (!this.jumpMenu) {
+        mixinHighlightPrimary(false)
+      }
     }
 
     if (

--- a/packages/vue/src/utils/mixins.ts
+++ b/packages/vue/src/utils/mixins.ts
@@ -160,7 +160,7 @@ export const mixinIsActivePath = (itemPath: string): Boolean => {
       // special treatment since EDU combines News & Events in the main nav
       return path.startsWith('/edu/news')
     } else {
-      return currentPath.startsWith(path)
+      return currentPath.startsWith(ancestorPath)
     }
   }
   return false

--- a/packages/vue/src/utils/mixins.ts
+++ b/packages/vue/src/utils/mixins.ts
@@ -149,14 +149,18 @@ export const mixinHighlightPrimary = (value: boolean) => {
     */
 export const mixinIsActivePath = (itemPath: string): Boolean => {
   const route = useRoute()
-  const currentPath = route ? route.path : null
-  const path = itemPath
-  const ancestorPath = path ? (path.endsWith('/') ? path : path + '/') : null
+  const currentPath = route ? route.path : false
+  const path = itemPath.startsWith('http') ? itemPath.replace(/^.*\/\/[^/]+/, '') : itemPath
+  const ancestorPath = path ? (path.endsWith('/') ? path : path + '/') : false
+
   if (currentPath && path && ancestorPath) {
     if (currentPath === path) {
       return true
+    } else if (currentPath.startsWith('/edu/events')) {
+      // special treatment since EDU combines News & Events in the main nav
+      return path.startsWith('/edu/news')
     } else {
-      return currentPath.startsWith(ancestorPath)
+      return currentPath.startsWith(path)
     }
   }
   return false


### PR DESCRIPTION
### Checklist

- [ ] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Address latest feedback in https://github.com/nasa-jpl/www/issues/189

Fixes `checkActive` function to handle both a path and a full url when checking for active state.

## Instructions to test

<!-- Provide instructions on how a reviewer can verify your work. -->

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
