### PR TITLE
Cleans up logic for switching between different content type aliases, adds EDU Search keys

### DIFF
--- a/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
+++ b/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
@@ -10,6 +10,7 @@
     class="border-gray-light-mid col-span-3 pb-4 mb-4 border-b"
   >
     <!-- bucket key param -->
+    {{ contentAliases }}
     <legend class="md:mb-3 text-body-md mb-2 font-bold leading-normal tracking-wide">
       {{ groupTitle }}
     </legend>
@@ -63,6 +64,8 @@
 <script lang="ts">
 // @ts-nocheck
 import isEqual from 'lodash/isEqual.js'
+import { lookupContentType } from './../../utils/lookupContentType'
+
 export default {
   name: 'SearchFilterGroup',
   props: {
@@ -154,67 +157,8 @@ export default {
       }
     },
     prettyFilterNames(key) {
-      if (key === 'news.News') {
-        return 'News & Features'
-      }
-      if (key === 'home.HomePage') {
-        return 'Homepage'
-      }
-      if (key === 'missions.Mission') {
-        return 'Missions'
-      }
-      if (key === 'events.EventPage') {
-        return 'Events'
-      }
-      if (key === 'image_detail.ImageDetailPage') {
-        return 'Images'
-      }
-      if (key === 'audio_detail.AudioIndexPage') {
-        return 'Audio Index'
-      }
-      if (key === 'audio_detail.AudioDetailPage') {
-        return 'Audio'
-      }
-      if (key === 'infographics.InfographicsDetailPage') {
-        return 'Infographics'
-      }
-      if (key === 'image_detail.CuratedGalleryPage') {
-        return 'Curated Gallery'
-      }
-      if (key === 'topics.TopicPage') {
-        return 'Topics'
-      }
-      if (key === 'asteroid_watch.AsteroidWatchIndexPage') {
-        return 'Asteroid Watch Index'
-      }
-      if (key === 'asteroid_watch.AsteroidWatchContentPage') {
-        return 'Asteroid Watch'
-      }
-      if (key === 'missions.MissionsIndexPage') {
-        return 'Missions Index'
-      }
-      if (key === 'information_pages.ContentPage') {
-        return 'Information pages'
-      }
-      if (key === 'robotics.RobotPage') {
-        return 'Robots'
-      }
-      if (key === 'video_detail.VideoDetailPage') {
-        return 'Video'
-      }
-      if (key === 'podcasts.PodcastPage') {
-        return 'Podcasts'
-      }
-      if (key === 'go_pages.GoHomePage') {
-        return 'Go Sites'
-      }
-      if (key === 'press_kits.PressKitHomePage') {
-        return 'Press Kits'
-      }
-      if (key === 'profiles.ProfilePage') {
-        return 'People'
-      }
-      return key
+      const name = lookupContentType(key, 'model', 'label')
+      return name ? name : key
     }
   }
 }

--- a/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
+++ b/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
@@ -10,7 +10,6 @@
     class="border-gray-light-mid col-span-3 pb-4 mb-4 border-b"
   >
     <!-- bucket key param -->
-    {{ contentAliases }}
     <legend class="md:mb-3 text-body-md mb-2 font-bold leading-normal tracking-wide">
       {{ groupTitle }}
     </legend>

--- a/packages/vue/src/components/SearchResultCard/SearchResultCard.vue
+++ b/packages/vue/src/components/SearchResultCard/SearchResultCard.vue
@@ -6,9 +6,7 @@
       size="lg"
       :data="{
         page: {
-          __typename: pageContentType
-            ? (searchContentTypeToPageType[pageContentType] as string)
-            : undefined,
+          __typename: pageContentType ? getInterfaceFromEskey(pageContentType) : undefined,
           url,
           type,
           label: topic,
@@ -221,7 +219,7 @@ import BaseImage from './../BaseImage/BaseImage.vue'
 import BaseImagePlaceholder from './../BaseImagePlaceholder/BaseImagePlaceholder.vue'
 import EventCard from './../EventCard/EventCard.vue'
 import BlockLinkCard from './../BlockLinkCard/BlockLinkCard.vue'
-import { searchContentTypeToPageType } from './../../constants'
+import { lookupContentType } from '../../utils/lookupContentType'
 import type { HeadingLevel } from './../BaseHeading/BaseHeading.vue'
 
 export default defineComponent({
@@ -343,9 +341,11 @@ export default defineComponent({
     }
   },
   computed: {
-    ...mapStores(useThemeStore),
-    searchContentTypeToPageType() {
-      return searchContentTypeToPageType
+    ...mapStores(useThemeStore)
+  },
+  methods: {
+    getInterfaceFromEskey(key: string) {
+      return lookupContentType(key, 'eskey', 'interface')
     }
   }
 })

--- a/packages/vue/src/components/SearchResultGridItem/SearchResultGridItem.vue
+++ b/packages/vue/src/components/SearchResultGridItem/SearchResultGridItem.vue
@@ -98,7 +98,7 @@ import BaseImagePlaceholder from './../BaseImagePlaceholder/BaseImagePlaceholder
 import BlockLinkCard from './../BlockLinkCard/BlockLinkCard.vue'
 import BlockLinkTile from './../BlockLinkTile/BlockLinkTile.vue'
 import CalendarChip from './../CalendarChip/CalendarChip.vue'
-import { searchContentTypeToPageType } from './../../constants'
+import { lookupContentType } from '../../utils/lookupContentType'
 import type { HeadingLevel } from './../BaseHeading/BaseHeading.vue'
 
 export default defineComponent({
@@ -177,12 +177,9 @@ export default defineComponent({
   },
   computed: {
     ...mapStores(useThemeStore),
-    searchContentTypeToPageType() {
-      return searchContentTypeToPageType
-    },
     typename() {
       return this.pageContentType
-        ? (this.searchContentTypeToPageType[this.pageContentType] as string)
+        ? lookupContentType(this.pageContentType, 'eskey', 'interface')
         : undefined
     }
   }

--- a/packages/vue/src/constants.ts
+++ b/packages/vue/src/constants.ts
@@ -1,4 +1,4 @@
-import type { DictionaryInterface, PillDictionaryInterface } from './interfaces'
+import type { PillDictionaryInterface } from './interfaces'
 
 export const eduMetadataDictionary: PillDictionaryInterface = {
   EDUEventPage: {
@@ -69,14 +69,184 @@ export const eduMetadataDictionary: PillDictionaryInterface = {
   }
 }
 
-// TODO: finish this
-export const searchContentTypeToPageType: DictionaryInterface = {
-  news_news: 'News',
-  events_eventpage: 'EventPage',
-  missions_mission: 'Mission',
-  edu_events_edueventpage: 'EDUEventPage',
-  edu_resources_educollectionsdetailpage: 'EDUCollectionsDetailPage',
-  edu_resources_eduexplainerarticlepage: 'EDUExplainerArticlePage',
-  edu_resources_edulessonpage: 'EDULessonPage',
-  edu_resources_eduteachablemomentpage: 'EDUTeachableMomentPage'
+interface contentTypeObject {
+  model: string
+  label: string
 }
+
+export const contentTypes: contentTypeObject[] = [
+  {
+    model: 'news.News',
+    label: 'News & Features'
+  },
+  {
+    model: 'home.HomePage',
+    label: 'Homepage'
+  },
+  {
+    model: 'missions.Mission',
+    label: 'Missions'
+  },
+  {
+    model: 'events.EventPage',
+    label: 'Events'
+  },
+  {
+    model: 'image_detail.ImageDetailPage',
+    label: 'Images'
+  },
+  {
+    model: 'audio_detail.AudioIndexPage',
+    label: 'Audio Index'
+  },
+  {
+    model: 'audio_detail.AudioDetailPage',
+    label: 'Audio'
+  },
+  {
+    model: 'infographics.InfographicsDetailPage',
+    label: 'Infographics'
+  },
+  {
+    model: 'image_detail.CuratedGalleryPage',
+    label: 'Curated Gallery'
+  },
+  {
+    model: 'topics.TopicPage',
+    label: 'Topics'
+  },
+  {
+    model: 'asteroid_watch.AsteroidWatchIndexPage',
+    label: 'Asteroid Watch Index'
+  },
+  {
+    model: 'asteroid_watch.AsteroidWatchContentPage',
+    label: 'Asteroid Watch'
+  },
+  {
+    model: 'missions.MissionsIndexPage',
+    label: 'Missions Index'
+  },
+  {
+    model: 'information_pages.ContentPage',
+    label: 'Information pages'
+  },
+  {
+    model: 'robotics.RobotPage',
+    label: 'Robots'
+  },
+  {
+    model: 'video_detail.VideoDetailPage',
+    label: 'Video'
+  },
+  {
+    model: 'podcasts.PodcastPage',
+    label: 'Podcasts'
+  },
+  {
+    model: 'go_pages.GoHomePage',
+    label: 'Go Sites'
+  },
+  {
+    model: 'press_kits.PressKitHomePage',
+    label: 'Press Kits'
+  },
+  {
+    model: 'profiles.ProfilePage',
+    label: 'People'
+  },
+  // EDU content types
+  {
+    model: 'edu_home.EDUHomePage',
+    label: 'Education Homepage'
+  },
+  {
+    model: 'edu_information_pages.EDUContentPage',
+    label: 'Information Pages'
+  },
+  {
+    model: 'edu_news.EDUNewsIndexPage',
+    label: 'News Index'
+  },
+  {
+    model: 'edu_events.EDUEventsIndexPage',
+    label: 'Events Index'
+  },
+  {
+    model: 'edu_events.EDUEventPage',
+    label: 'Events'
+  },
+  {
+    model: 'edu_news.EDUNewsPage',
+    label: 'News'
+  },
+  {
+    model: 'edu_resources.EDUExplainerArticlePage',
+    label: 'Explainer Articles'
+  },
+  {
+    model: 'edu_resources.EDUResourceLibraryIndexPage',
+    label: 'Resource Library Index'
+  },
+  {
+    model: 'edu_resources.EDULessonPage',
+    label: 'Lesson Plans'
+  },
+  {
+    model: 'edu_resources.EDUTeachableMomentPage',
+    label: 'Teachable Moments'
+  },
+  {
+    model: 'edu_resources.EDUCollectionsDetailPage',
+    label: 'Collections'
+  },
+  {
+    model: 'edu_resources.EDUGalleryDetailPage',
+    label: 'Galleries'
+  },
+  {
+    model: 'edu_resources.EDUImageDetailPage',
+    label: 'Images'
+  },
+  {
+    model: 'edu_resources.EDUInfographicDetailPage',
+    label: 'Infographics'
+  },
+  {
+    model: 'edu_resources.EDUDocumentDetailPage',
+    label: 'Documents'
+  },
+  {
+    model: 'edu_resources.EDUVideoDetailPage',
+    label: 'Videos'
+  }
+]
+
+interface contentAliasObject extends contentTypeObject {
+  interface?: string
+  eskey?: string
+}
+const getContentAliases = (): contentAliasObject[] => {
+  const getInterface = (contentType: contentTypeObject) => {
+    const model = contentType.model
+    return model ? model.split('.').pop() : undefined
+  }
+  const getEskey = (contentType: contentTypeObject) => {
+    const model = contentType.model
+    return model ? model.toLowerCase().replace('.', '_') : undefined
+  }
+
+  let entries: contentAliasObject[] = []
+
+  contentTypes.forEach((contentType) => {
+    const entry: contentAliasObject = {
+      ...contentType,
+      interface: getInterface(contentType),
+      eskey: getEskey(contentType)
+    }
+    entries.push(entry)
+  })
+  return entries
+}
+
+export const contentAliases = getContentAliases()

--- a/packages/vue/src/utils/lookupContentType.ts
+++ b/packages/vue/src/utils/lookupContentType.ts
@@ -1,0 +1,22 @@
+import { contentAliases } from './../constants'
+
+export const getInterfaceFromEskey = (eskey: string) => {
+  let match = undefined
+  contentAliases.forEach((alias) => (alias.eskey === eskey ? (match = alias.interface) : undefined))
+  return match
+}
+
+export const getEskeyFromInterface = (interfaceName: string) => {
+  let match = undefined
+  contentAliases.forEach((alias) =>
+    alias.interface === interfaceName ? (match = alias.eskey) : undefined
+  )
+  return match
+}
+
+export const lookupContentType = (key: string, source: string, target: string) => {
+  let match = undefined
+  // @ts-expect-error
+  contentAliases.forEach((entry) => (entry[source] === key ? (match = entry[target]) : undefined))
+  return match
+}


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

- integrates `prettyFilterNames` into a new `lookupContentType` method that can convert between interface name (`EDUImageDetailPage`), model name (`edu_resources.EDUImageDetailPage`), elastic search key (`edu_resources_eduimagedetailpage`), and filter name (`Images`).
- adds all EDU content types to `lookupContentType`

## Instructions to test

<!-- Provide instructions on how a reviewer can verify your work. -->

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
