### PR TITLE
fixes: Lesson Template and ClientOnly

### DIFF
--- a/apps/vue-storybook/.storybook/_mock-components.js
+++ b/apps/vue-storybook/.storybook/_mock-components.js
@@ -20,6 +20,11 @@ export default (app) => {
       '<a href="#" @click.prevent="log()" :class="this.class" v-bind="$attrs"><slot></slot></a>'
   })
 
+  // Nuxt ClientOnly
+  app.component('ClientOnly', {
+    template: '<slot></slot>'
+  })
+
   // use static dsn widget instead of fetch
   app.component('FetchDsnWidget', DsnWidget)
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -39,7 +39,6 @@
     "twitter-widgets": "^2.0.0",
     "vue": "^3.4.21",
     "vue-bind-once": "^0.2.1",
-    "vue-observe-visibility": "^1.0.0",
     "vue3-compare-image": "^1.2.5",
     "vue3-observe-visibility": "^1.0.1"
   },

--- a/packages/vue/src/components/BlockImageComparison/BlockImageComparison.vue
+++ b/packages/vue/src/components/BlockImageComparison/BlockImageComparison.vue
@@ -1,13 +1,15 @@
 <template>
   <div v-if="data">
-    <VueCompareImage
-      v-if="theBeforeImageSrc && theAfterImageSrc"
-      class="h-full animate-fadeIn"
-      :left-image="theBeforeImageSrc.url"
-      left-image-alt="Left image"
-      :right-image="theAfterImageSrc.url"
-      right-image-alt="Right image"
-    />
+    <client-only>
+      <VueCompareImage
+        v-if="theBeforeImageSrc && theAfterImageSrc"
+        class="h-full animate-fadeIn"
+        :left-image="theBeforeImageSrc.url"
+        left-image-alt="Left image"
+        :right-image="theAfterImageSrc.url"
+        right-image-alt="Right image"
+      />
+    </client-only>
     <div
       v-if="data.caption || customDetailUrl"
       class="lg:px-0 p-4 pb-0 print:pl-0"

--- a/packages/vue/src/components/BlockImageComparison/BlockImageComparison.vue
+++ b/packages/vue/src/components/BlockImageComparison/BlockImageComparison.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="data">
-    <client-only>
+    <ClientOnly>
       <VueCompareImage
         v-if="theBeforeImageSrc && theAfterImageSrc"
         class="h-full animate-fadeIn"
@@ -9,7 +9,7 @@
         :right-image="theAfterImageSrc.url"
         right-image-alt="Right image"
       />
-    </client-only>
+    </ClientOnly>
     <div
       v-if="data.caption || customDetailUrl"
       class="lg:px-0 p-4 pb-0 print:pl-0"

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
@@ -29,7 +29,9 @@ interface EduLessonProcedureBlocks {
   blocks: StreamfieldBlockData[]
 }
 export interface EduLessonProcedure {
-  procedure: EduLessonProcedureBlocks
+  sectionHeading?: string
+  steps?: EduLessonProcedureBlocks[]
+  stepsNumbering?: boolean
 }
 
 interface PageEduLessonObject extends PageEduResourcesObject {
@@ -192,8 +194,8 @@ const consolidatedBlocks = computed(() => {
       } else if (section === 'procedures' && data.procedures?.length) {
         // get blocks in nested procedures
         data.procedures.forEach((item) => {
-          if (item.procedure?.blocks?.length) {
-            blocks.push(...item.procedure.blocks)
+          if (item.steps?.length) {
+            blocks.push(...item.steps)
           }
         })
       }

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
@@ -332,7 +332,7 @@ const consolidatedSections = computed((): EduLessonSectionObject[] => {
       v-for="(value, _key) in consolidatedSections"
       :key="_key"
     >
-      <template v-if="value.blocks?.length || value.procedures?.length">
+      <template v-if="value.blocks?.length || value.procedures?.length || value.text?.length">
         <BlockStreamfield
           v-if="value.type === 'streamfield'"
           :data="value.blocks"

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue'
 import type {
-  BlockData,
   ImageObject,
   PageEduResourcesObject,
   StreamfieldBlockData
@@ -24,12 +23,12 @@ import AboutTheAuthor from './../../../components/AboutTheAuthor/AboutTheAuthor.
 import { HeadingLevel } from '../../../components/BaseHeading/BaseHeading.vue'
 
 interface EduLessonSectionObject extends PageEduLessonSectionProps {
-  type?: 'streamfield'
+  type?: string
 }
 interface EduLessonProcedureBlocks {
   blocks: StreamfieldBlockData[]
 }
-interface EduLessonProcedure {
+export interface EduLessonProcedure {
   procedure: EduLessonProcedureBlocks
 }
 
@@ -218,7 +217,7 @@ const consolidatedBlocks = computed(() => {
 
 // organize data to render with PageEduLessonSection component
 const consolidatedSections = computed((): EduLessonSectionObject[] => {
-  const sections = []
+  const sections: EduLessonSectionObject[] = []
   // include custom top section
   if (keyedCustomSections.value && keyedCustomSections.value['top']) {
     sections.push({ type: 'streamfield', blocks: keyedCustomSections.value['top'] })
@@ -226,9 +225,7 @@ const consolidatedSections = computed((): EduLessonSectionObject[] => {
   sectionOrder.forEach((section) => {
     if (data && data[section]) {
       sections.push({
-        heading: staticSectionHeadings.value
-          ? (staticSectionHeadings.value[section] as BlockData)
-          : undefined,
+        heading: staticSectionHeadings.value ? staticSectionHeadings.value[section] : undefined,
         blocks: section !== 'materials' && section !== 'procedures' ? data[section] : undefined,
         text: section === 'materials' ? data[section] : undefined,
         procedures: section === 'procedures' ? data[section] : undefined
@@ -243,7 +240,11 @@ const consolidatedSections = computed((): EduLessonSectionObject[] => {
   if (keyedCustomSections.value && keyedCustomSections.value['bottom']) {
     sections.push({ type: 'streamfield', blocks: keyedCustomSections.value['bottom'] })
   }
-  return sections as EduLessonSectionObject[]
+  const filteredSections = sections.filter(
+    (item) => item.text !== undefined || item.blocks !== undefined || item.procedures !== undefined
+  )
+
+  return filteredSections
 })
 </script>
 <template>

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
@@ -31,14 +31,14 @@ const props = withDefaults(defineProps<PageEduLessonSectionProps>(), {
 const { heading, blocks, image } = reactive(props)
 
 const anchorId = computed(() => {
-  return 'lesson_' + camelCase(heading.heading)
+  return 'lesson_' + camelCase(heading?.heading)
 })
 </script>
 <template>
   <section
     :id="anchorId"
     class="PageEduLessonSection"
-    :aria-label="heading.heading"
+    :aria-label="heading?.heading"
   >
     <LayoutHelper
       indent="col-3"

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
@@ -5,6 +5,7 @@ import type { ImageObject, StreamfieldBlockData } from './../../../interfaces'
 import BlockHeading, {
   type BlockHeadingObject
 } from './../../../components/BlockHeading/BlockHeading.vue'
+import type { EduLessonProcedure } from './PageEduLesson.vue'
 import BaseHeading from './../../../components/BaseHeading/BaseHeading.vue'
 import BlockText from './../../../components/BlockText/BlockText.vue'
 import LayoutHelper from './../../../components/LayoutHelper/LayoutHelper.vue'
@@ -12,15 +13,9 @@ import BlockImageStandard from './../../../components/BlockImage/BlockImageStand
 import BlockStreamfield from './../../../components/BlockStreamfield/BlockStreamfield.vue'
 
 export interface PageEduLessonSectionProps {
-  heading: BlockHeadingObject
+  heading?: BlockHeadingObject
   blocks?: StreamfieldBlockData[]
-  procedures?: {
-    sectionHeading: string
-    stepsNumbering: boolean
-    steps: {
-      blocks: StreamfieldBlockData[]
-    }[]
-  }[]
+  procedures?: EduLessonProcedure[]
   text?: string
   image?: ImageObject
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,9 +542,6 @@ importers:
       vue-bind-once:
         specifier: ^0.2.1
         version: 0.2.1(vue@3.4.27(typescript@5.4.5))
-      vue-observe-visibility:
-        specifier: ^1.0.0
-        version: 1.0.0
       vue3-compare-image:
         specifier: ^1.2.5
         version: 1.2.5(vue@3.4.27(typescript@5.4.5))
@@ -9002,9 +8999,6 @@ packages:
     resolution: {integrity: sha512-K3wt3iVmNGaFEOUR4JIThQRWfqokxLfnPslD41FDZB2ajXp789+wCqJyGYlIFsvEQ2P61PInw6/ph5iiqg51gg==}
     peerDependencies:
       vue: '>=2'
-
-  vue-observe-visibility@1.0.0:
-    resolution: {integrity: sha512-s5TFh3s3h3Mhd3jaz3zGzkVHKHnc/0C/gNr30olO99+yw2hl3WBhK3ng3/f9OF+qkW4+l7GkmwfAzDAcY3lCFg==}
 
   vue-observe-visibility@2.0.0-alpha.1:
     resolution: {integrity: sha512-flFbp/gs9pZniXR6fans8smv1kDScJ8RS7rEpMjhVabiKeq7Qz3D9+eGsypncjfIyyU84saU88XZ0zjbD6Gq/g==}
@@ -19809,8 +19803,6 @@ snapshots:
   vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.4.27(typescript@5.4.5)):
     dependencies:
       vue: 3.4.27(typescript@5.4.5)
-
-  vue-observe-visibility@1.0.0: {}
 
   vue-observe-visibility@2.0.0-alpha.1(vue@3.4.27(typescript@5.4.5)):
     dependencies:


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses QA from:
- https://github.com/nasa-jpl/www/issues/99#issuecomment-2318156030

Also adds `<ClientOnly>` back to `BlockImageComparison` and includes a mock component for Storybook. `<ClientOnly>` is a native Nuxt3 component.

## Instructions to test

<!-- Provide instructions on how a reviewer can verify your work. -->

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [x] Firefox
- [ ] Safari
- [ ] Edge
