### PR TITLE
fix: Gallery Detail Page and BlockTeaser

### DIFF
--- a/packages/vue/src/components/BlockTeaser/BlockTeaser.vue
+++ b/packages/vue/src/components/BlockTeaser/BlockTeaser.vue
@@ -44,7 +44,7 @@
         <BaseButton
           v-if="theTeaserPage"
           variant="primary"
-          :href="theTeaserPage.url"
+          :to="theTeaserPage.url"
           class="mt-8"
           :aria-label="`${theButtonText} - ${theHeading}`"
         >

--- a/packages/vue/src/templates/edu/PageEduGalleryDetail/PageEduGalleryDetail.vue
+++ b/packages/vue/src/templates/edu/PageEduGalleryDetail/PageEduGalleryDetail.vue
@@ -76,8 +76,9 @@ const { data } = reactive(props)
     >
       <DetailHeadline
         :title="data.title"
-        label="Slideshow"
+        label="Gallery"
         :publication-date="data.publicationDate"
+        pill-color="secondary"
         schema
         pill
         hide-date


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses:
- https://github.com/nasa-jpl/www/issues/441#issuecomment-2338615606

Changes:
- Fixes pill label and color on EDU Gallery detail pages
- Fixes link attribute in BlockTeaser (fixes stray `/home/` links)

## Instructions to test

1. `make vue-storybook`
2. View the Gallery detail page story: http://localhost:6006/?path=/story/templates-edu-pageedugallerydetail--base-story&globals=theme:ThemeEdu

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
