### PR TITLE
feature: edu resource subjects accordion filter group

### DIFF
--- a/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.stories.js
+++ b/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.stories.js
@@ -58,3 +58,53 @@ export const DateFilter = {
     truncateFilters: true
   }
 }
+export const SubFilters = {
+  args: {
+    filterBy: [],
+    buckets: [
+      { key: 'Solar System', doc_count: 3308 },
+      { key: 'Earth', doc_count: 1179 },
+      { key: 'Stars and Galaxies', doc_count: 979 },
+      { key: 'Technology', doc_count: 480 }
+    ],
+    groupKey: 'topics',
+    groupTitle: 'Topic',
+    truncateFilters: false,
+    subFilters: {
+      solar_system: [
+        {
+          key: 'Sun',
+          agg: 'solar_system_area',
+          doc_count: 20
+        },
+        {
+          key: 'Mercury',
+          agg: 'solar_system_area',
+          doc_count: 21
+        },
+        {
+          key: 'Venus',
+          agg: 'solar_system_area',
+          doc_count: 22
+        }
+      ],
+      earth: [
+        {
+          key: 'Sea Level',
+          agg: 'solar_system_area',
+          doc_count: 20
+        },
+        {
+          key: 'Pollution',
+          agg: 'solar_system_area',
+          doc_count: 21
+        },
+        {
+          key: 'Climate Change',
+          agg: 'solar_system_area',
+          doc_count: 22
+        }
+      ]
+    }
+  }
+}

--- a/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.stories.js
+++ b/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.stories.js
@@ -59,6 +59,11 @@ export const DateFilter = {
   }
 }
 export const SubFilters = {
+  decorators: [
+    () => ({
+      template: '<div id="storyRoot" class="md:w-1/2 lg:w-1/3"><story /></div>'
+    })
+  ],
   args: {
     filterBy: [],
     buckets: [
@@ -89,6 +94,40 @@ export const SubFilters = {
         }
       ],
       earth: [
+        {
+          key: 'Sea Level',
+          agg: 'solar_system_area',
+          doc_count: 20
+        },
+        {
+          key: 'Pollution',
+          agg: 'solar_system_area',
+          doc_count: 21
+        },
+        {
+          key: 'Climate Change',
+          agg: 'solar_system_area',
+          doc_count: 22
+        }
+      ],
+      stars_and_galaxies: [
+        {
+          key: 'Sea Level',
+          agg: 'solar_system_area',
+          doc_count: 20
+        },
+        {
+          key: 'Pollution',
+          agg: 'solar_system_area',
+          doc_count: 21
+        },
+        {
+          key: 'Climate Change',
+          agg: 'solar_system_area',
+          doc_count: 22
+        }
+      ],
+      technology: [
         {
           key: 'Sea Level',
           agg: 'solar_system_area',

--- a/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
+++ b/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
@@ -21,6 +21,7 @@
         <SearchFilterGroupAccordionItem
           v-if="hasSubFilters(bucket.key_as_string || bucket.key)"
           class="w-auto"
+          :init-open="subFilterIsInQueryParams(bucket.key_as_string || bucket.key)"
         >
           <template #header>
             <!-- correct for zero based index -->
@@ -175,6 +176,10 @@ export default {
     subFilters: {
       type: Object as PropType<SubFiltersObject>,
       default: undefined
+    },
+    subFilterAggKey: {
+      type: String,
+      default: undefined
     }
   },
   emits: ['update:filterBy'],
@@ -267,6 +272,20 @@ export default {
         return true
       }
       return undefined
+    },
+    subFilterIsInQueryParams(bucketKey) {
+      const subFilters = this.getSubFilters(bucketKey)
+      let state = false
+      if (subFilters?.length) {
+        subFilters.forEach((subFilter) => {
+          const agg = subFilter.agg
+          const key = subFilter.key
+          if (agg && key && this.$route.query[agg]?.includes(key)) {
+            state = true
+          }
+        })
+      }
+      return state
     },
     getSubFilters(filterKey) {
       const lookupKey = this.getSubFilterParentKey(filterKey)

--- a/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
+++ b/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
@@ -51,7 +51,7 @@
                 <span class="font-extrabold">{{
                   prettyFilterNames(bucket.key_as_string ? bucket.key_as_string : bucket.key)
                 }}</span>
-                <span class="text-gray-mid-dark font-normal">
+                <span class="text-gray-mid-dark font-normal text-sm">
                   ({{ bucket.doc_count.toLocaleString() }})
                 </span>
               </label>
@@ -103,7 +103,9 @@
               class="form-check-label pl-2 tracking-normal align-middle"
             >
               {{ prettyFilterNames(bucket.key_as_string ? bucket.key_as_string : bucket.key) }}
-              <span class="text-gray-mid-dark"> ({{ bucket.doc_count.toLocaleString() }}) </span>
+              <span class="text-gray-mid-dark text-sm">
+                ({{ bucket.doc_count.toLocaleString() }})
+              </span>
             </label>
           </div>
         </template>

--- a/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
+++ b/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
@@ -218,10 +218,10 @@ export default {
             if (this.subFilters[key]) {
               // console.log(this.subFilters[key])
               // find the subfilter with matching key
-              const match = this.subFilters[key].some((subFilter) => {
-                console.log(subFilter.key)
-                console.log(filterValue)
-                subFilter.key === filterValue
+              const match = this.subFilters[key].find((subFilter) => {
+                console.log('key', subFilter.key)
+                console.log('filterValue', filterValue)
+                return subFilter.key === filterValue
               })
               console.log(match)
               // get the aggregation key
@@ -237,6 +237,7 @@ export default {
           let query = Object.assign({}, this.$route.query)
           if (newVal.length > 0) {
             const theKey = getFilterUpdatedKey(this.groupKey, newVal.toString())
+            console.log(theKey)
             query = {
               ...this.$route.query,
               page: 1,

--- a/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
+++ b/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
@@ -49,6 +49,7 @@
         </div>
 
         <!-- dynamic slots for subFilters -->
+        <!-- TODO: turn this into an accordion -->
         <div
           v-if="
             (bucket.key_as_string || bucket.key) &&

--- a/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
+++ b/packages/vue/src/components/SearchFilterGroup/SearchFilterGroup.vue
@@ -18,53 +18,95 @@
         ref="buckets"
         class="form-group form-check"
       >
-        <!-- correct for zero based index -->
-        <div
-          v-if="!truncateFilters || index <= checkbox.checkboxLimit - 1"
-          class="flex my-2"
+        <SearchFilterGroupAccordionItem
+          v-if="hasSubFilters(bucket.key_as_string || bucket.key)"
+          class="w-auto"
         >
-          <input
-            :id="
-              bucket.key_as_string
-                ? generateId(bucket.key_as_string, groupKey)
-                : generateId(bucket.key, groupKey)
-            "
-            v-model="filterByHandler"
-            type="checkbox"
-            :value="bucket.key_as_string ? bucket.key_as_string : bucket.key"
-            class="text-primary focus:ring-2 focus:ring-primary flex-shrink-0 w-5 h-5 mt-px mr-1 align-middle border rounded-none"
-          />
-          <!-- 'key_as_string' exists for dates to have a human readable version -->
-          <label
-            :for="
-              bucket.key_as_string
-                ? generateId(bucket.key_as_string, groupKey)
-                : generateId(bucket.key, groupKey)
-            "
-            class="form-check-label pl-2 tracking-normal align-middle"
-          >
-            {{ prettyFilterNames(bucket.key_as_string ? bucket.key_as_string : bucket.key) }}
-            <span class="text-gray-mid-dark"> ({{ bucket.doc_count.toLocaleString() }}) </span>
-          </label>
-        </div>
-
-        <!-- dynamic slots for subFilters -->
-        <!-- TODO: turn this into an accordion -->
-        <div
-          v-if="
-            (bucket.key_as_string || bucket.key) &&
-            getSubFilters(bucket.key_as_string || bucket.key) &&
-            subFilterParentKeys?.length
-          "
-          class="block"
-        >
+          <template #header>
+            <!-- correct for zero based index -->
+            <div
+              v-if="!truncateFilters || index <= checkbox.checkboxLimit - 1"
+              class="flex flex-grow"
+            >
+              <input
+                :id="
+                  bucket.key_as_string
+                    ? generateId(bucket.key_as_string, groupKey)
+                    : generateId(bucket.key, groupKey)
+                "
+                v-model="filterByHandler"
+                type="checkbox"
+                :value="bucket.key_as_string ? bucket.key_as_string : bucket.key"
+                class="text-primary focus:ring-2 focus:ring-primary flex-shrink-0 w-5 h-5 mt-px mr-1 align-middle border rounded-none"
+              />
+              <!-- 'key_as_string' exists for dates to have a human readable version -->
+              <label
+                :for="
+                  bucket.key_as_string
+                    ? generateId(bucket.key_as_string, groupKey)
+                    : generateId(bucket.key, groupKey)
+                "
+                class="form-check-label pl-2 tracking-normal align-middle"
+              >
+                <span class="font-extrabold">{{
+                  prettyFilterNames(bucket.key_as_string ? bucket.key_as_string : bucket.key)
+                }}</span>
+                <span class="text-gray-mid-dark font-normal">
+                  ({{ bucket.doc_count.toLocaleString() }})
+                </span>
+              </label>
+            </div>
+          </template>
+          <template #default>
+            <!-- dynamic slots for subFilters -->
+            <div
+              v-if="
+                (bucket.key_as_string || bucket.key) &&
+                getSubFilters(bucket.key_as_string || bucket.key) &&
+                subFilterParentKeys?.length
+              "
+              class="block"
+            >
+              <div
+                v-if="hasSubFilters(bucket.key_as_string || bucket.key)"
+                class="SubFilters"
+              >
+                <slot :name="`slot_${getSubFilterParentKey(bucket.key_as_string || bucket.key)}`" />
+              </div>
+            </div>
+          </template>
+        </SearchFilterGroupAccordionItem>
+        <template v-else>
+          <!-- correct for zero based index -->
           <div
-            v-if="hasSubFilter(bucket.key_as_string || bucket.key)"
-            class="SubFilters pl-5"
+            v-if="!truncateFilters || index <= checkbox.checkboxLimit - 1"
+            class="flex my-2"
           >
-            <slot :name="`slot_${getSubFilterParentKey(bucket.key_as_string || bucket.key)}`" />
+            <input
+              :id="
+                bucket.key_as_string
+                  ? generateId(bucket.key_as_string, groupKey)
+                  : generateId(bucket.key, groupKey)
+              "
+              v-model="filterByHandler"
+              type="checkbox"
+              :value="bucket.key_as_string ? bucket.key_as_string : bucket.key"
+              class="text-primary focus:ring-2 focus:ring-primary flex-shrink-0 w-5 h-5 mt-px mr-1 align-middle border rounded-none"
+            />
+            <!-- 'key_as_string' exists for dates to have a human readable version -->
+            <label
+              :for="
+                bucket.key_as_string
+                  ? generateId(bucket.key_as_string, groupKey)
+                  : generateId(bucket.key, groupKey)
+              "
+              class="form-check-label pl-2 tracking-normal align-middle"
+            >
+              {{ prettyFilterNames(bucket.key_as_string ? bucket.key_as_string : bucket.key) }}
+              <span class="text-gray-mid-dark"> ({{ bucket.doc_count.toLocaleString() }}) </span>
+            </label>
           </div>
-        </div>
+        </template>
       </div>
     </div>
     <div v-else><span class="text-sm text-gray-mid-dark">No matching filters</span></div>
@@ -95,9 +137,13 @@ import { mapStores } from 'pinia'
 import { useThemeStore } from '../../store/theme'
 import { lookupContentType } from './../../utils/lookupContentType'
 import { SubFiltersObject } from './../../interfaces'
+import SearchFilterGroupAccordionItem from './../SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue'
 
 export default {
   name: 'SearchFilterGroup',
+  components: {
+    SearchFilterGroupAccordionItem
+  },
   props: {
     filterBy: {
       type: Array,
@@ -212,7 +258,7 @@ export default {
       }
       return key
     },
-    hasSubFilter(filterKey) {
+    hasSubFilters(filterKey) {
       const lookupKey = this.getSubFilterParentKey(filterKey)
       // check if any of the keys are populated in subFilters
       if (this.subFilters && lookupKey && this.subFilters[lookupKey]) {

--- a/packages/vue/src/components/SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue
+++ b/packages/vue/src/components/SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue
@@ -40,7 +40,7 @@ const emit = defineEmits(['filterGroupAccordionItemOpened', 'filterGroupAccordio
 </script>
 <template>
   <div
-    class="SearchFilterGroupAccordionItem border-t pt-3"
+    class="SearchFilterGroupAccordionItem border-t pt-2.5"
     :class="{
       '-open border-gray-light-mid  -mb-px': !isHidden,
       'border-transparent mb-3': isHidden

--- a/packages/vue/src/components/SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue
+++ b/packages/vue/src/components/SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue
@@ -28,10 +28,10 @@ const emit = defineEmits(['filterGroupAccordionItemOpened', 'filterGroupAccordio
 </script>
 <template>
   <div
-    class="SearchFilterGroupAccordionItem border-t pt-2"
+    class="SearchFilterGroupAccordionItem border-t pt-3"
     :class="{
       '-open border-gray-light-mid  -mb-px': !isHidden,
-      'border-transparent mb-2': isHidden
+      'border-transparent mb-3': isHidden
     }"
   >
     <div class="SearchFilterGroupAccordionItemHeader flex flex-row w-full content-between">
@@ -54,7 +54,7 @@ const emit = defineEmits(['filterGroupAccordionItemOpened', 'filterGroupAccordio
     </div>
     <div
       v-show="!isHidden"
-      class="SearchFilterGroupAccordionItemContent"
+      class="SearchFilterGroupAccordionItemContent text-sm"
     >
       <div
         v-bind-once="{ id: panelId, 'aria-labelledby': headingId }"
@@ -66,3 +66,10 @@ const emit = defineEmits(['filterGroupAccordionItemOpened', 'filterGroupAccordio
     </div>
   </div>
 </template>
+<style lang="scss">
+.SearchFilterGroupAccordionItemContent {
+  input.mt-px {
+    @apply mt-0 #{!important};
+  }
+}
+</style>

--- a/packages/vue/src/components/SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue
+++ b/packages/vue/src/components/SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue
@@ -52,6 +52,7 @@ const emit = defineEmits(['filterGroupAccordionItemOpened', 'filterGroupAccordio
         <button
           v-bind-once="{ id: headingId, 'aria-controls': panelId }"
           :aria-expanded="ariaExpanded"
+          aria-label="Expand"
           class="SearchFilterGroupAccordionItem-trigger group block w-auto text-body-lg pl-4 pr-1 -my-2"
           @click="handleClick()"
         >

--- a/packages/vue/src/components/SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue
+++ b/packages/vue/src/components/SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { uniqueId } from 'lodash'
+import IconPlus from './../Icons/IconPlus.vue'
+const ariaExpanded = ref(false)
+const isHidden = ref(true)
+const itemId = ref(uniqueId())
+
+const panelId = computed(() => {
+  return `filterGroup_accordion_panel_${itemId.value}`
+})
+
+const headingId = computed(() => {
+  return `filterGroup_accordion_heading_${itemId.value}`
+})
+
+const handleClick = () => {
+  ariaExpanded.value = !ariaExpanded.value
+  isHidden.value = !isHidden.value
+  if (isHidden.value) {
+    emit('filterGroupAccordionItemClosed')
+  } else {
+    emit('filterGroupAccordionItemOpened')
+  }
+}
+
+const emit = defineEmits(['filterGroupAccordionItemOpened', 'filterGroupAccordionItemClosed'])
+</script>
+<template>
+  <div
+    class="SearchFilterGroupAccordionItem border-t pt-2"
+    :class="{
+      '-open border-gray-light-mid  -mb-px': !isHidden,
+      'border-transparent mb-2': isHidden
+    }"
+  >
+    <div class="SearchFilterGroupAccordionItemHeader flex flex-row w-full content-between">
+      <template v-if="$slots.header">
+        <slot name="header"></slot>
+        <button
+          v-bind-once="{ id: headingId, 'aria-controls': panelId }"
+          :aria-expanded="ariaExpanded"
+          class="SearchFilterGroupAccordionItem-trigger group block w-auto text-body-lg pl-4 pr-1 -my-2"
+          @click="handleClick()"
+        >
+          <span
+            class="SearchFilterGroupAccordionItem-icon inline-block text-xs text-action flex-shrink-0 transform transition-transform"
+            :class="{ '!rotate-45': !isHidden }"
+          >
+            <IconPlus />
+          </span>
+        </button>
+      </template>
+    </div>
+    <div
+      v-show="!isHidden"
+      class="SearchFilterGroupAccordionItemContent"
+    >
+      <div
+        v-bind-once="{ id: panelId, 'aria-labelledby': headingId }"
+        role="region"
+        class="SearchFilterGroupAccordionItem-panel border-b border-gray-light-mid"
+      >
+        <slot name="default" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/vue/src/components/SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue
+++ b/packages/vue/src/components/SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue
@@ -1,9 +1,21 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, reactive, ref } from 'vue'
 import { uniqueId } from 'lodash'
 import IconPlus from './../Icons/IconPlus.vue'
+
+export interface SearchFilterGroupAccordionItemProps {
+  initOpen?: boolean
+}
+
+// define props
+const props = withDefaults(defineProps<SearchFilterGroupAccordionItemProps>(), {
+  initOpen: false
+})
+
+const { initOpen } = reactive(props)
+
 const ariaExpanded = ref(false)
-const isHidden = ref(true)
+const isHidden = ref(!initOpen)
 const itemId = ref(uniqueId())
 
 const panelId = computed(() => {

--- a/packages/vue/src/interfaces.ts
+++ b/packages/vue/src/interfaces.ts
@@ -185,6 +185,27 @@ export interface FooterResponse {
   footer: any
 }
 
+export interface EDUSubjectArea {
+  id: number
+  primarySubject: EduResourcesSubject
+  subjectArea: string
+}
+
+export interface SubFiltersObject {
+  [key: string]: {
+    parentBucketKey: string
+    aggParentKey: string
+    aggMapKey: string
+    subFilterKey: string
+  }
+}
+
+export interface EduSubjectAreasResponse {
+  eduSubjectAreas: {
+    eduSubjectAreas: EDUSubjectArea[]
+  }
+}
+
 export type Explorer1Theme = 'defaultTheme' | 'ThemeInternal' | 'ThemeEdu'
 
 export interface Attributes {

--- a/packages/vue/src/templates/PageImageDetail/PageImageDetail.vue
+++ b/packages/vue/src/templates/PageImageDetail/PageImageDetail.vue
@@ -159,7 +159,7 @@
                 <BaseLink
                   variant="none"
                   link-class="font-primary text-jpl-red hover:text-jpl-red-light w-full py-3 text-lg"
-                  to="/missions/?mission_target={{ item.target }}"
+                  :to="`/missions/?mission_target=${item.target}`"
                 >
                   {{ item.target }}
                 </BaseLink>


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses:
- https://github.com/nasa-jpl/www/issues/466

In cojunction with (many of these changes required updating `www/apps/frontend/components/FetchListingIndex.vue`):
- https://github.com/nasa-jpl/www/pull/551

Adds nested filter accordions by:
- Creating dynamic slots based on subFilter keys
- Populating dynamic slots in www/FetchListingIndex.vue to allow for reusing `SearchFilterGroups` and functionality already built to sync the url params with checkboxes
- Adding `SearchFilterGroupAccordionItem` component as a child component of `SearchFilterGroups`
- Checks route for subfilters and will automatically expand the appropriate accordion item if a sub-filter is in use.
- a bit verbose, code could probably be optimized, but this works for MVP

<!-- Describe your pull request. -->

## Instructions to test

<!-- Provide instructions on how a reviewer can verify your work. -->

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [x] Firefox
- [ ] Safari
- [ ] Edge
