### PR TITLE
fix: anchor links in mobile nav, long menus in Jump Nav

### DIFF
--- a/packages/vue/src/components/BlockHeading/BlockHeading.vue
+++ b/packages/vue/src/components/BlockHeading/BlockHeading.vue
@@ -57,7 +57,7 @@ export default defineComponent({
   &:target {
     @apply scroll-mt-14;
     @screen lg {
-      @apply scroll-mt-[8rem];
+      @apply scroll-mt-[7rem];
     }
   }
 }

--- a/packages/vue/src/components/NavJumpMenu/NavJumpMenu.stories.js
+++ b/packages/vue/src/components/NavJumpMenu/NavJumpMenu.stories.js
@@ -38,6 +38,23 @@ export const BaseStory = {
   }
 }
 
+export const ExtraLong = {
+  args: {
+    title: 'Page Title',
+    jumpLinks: [
+      ...JumpLinksData,
+      ...JumpLinksData,
+      ...JumpLinksData,
+      ...JumpLinksData,
+      ...JumpLinksData,
+      ...JumpLinksData,
+      ...JumpLinksData,
+      ...JumpLinksData
+    ],
+    invert: true
+  }
+}
+
 export const Light = {
   args: {
     title: 'Page Title',

--- a/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
+++ b/packages/vue/src/components/NavJumpMenu/NavJumpMenu.vue
@@ -18,6 +18,7 @@
         >
           <NavJumpMenuContent
             :key="index"
+            class="max-h-[72vh] overflow-y-auto"
             :item="item"
             v-bind="$attrs"
           />

--- a/packages/vue/src/components/NavSecondary/NavSecondaryDropdownContent.vue
+++ b/packages/vue/src/components/NavSecondary/NavSecondaryDropdownContent.vue
@@ -16,7 +16,8 @@
       :key="child_index"
     >
       <BaseLink
-        :to="child.path"
+        :to="child.path.startsWith('/') ? child.path : undefined"
+        :href="!child.path.startsWith('/') ? child.path : undefined"
         variant="none"
         :link-class="linkClass(child, child_index === item.children.length - 1)"
         exact
@@ -35,7 +36,8 @@
           class=""
         >
           <BaseLink
-            :to="grandchild.path"
+            :to="grandchild.path.startsWith('/') ? grandchild.path : undefined"
+            :href="!grandchild.path.startsWith('/') ? grandchild.path : undefined"
             variant="none"
             :link-class="
               nestedLinkClass(


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses feedback:
- https://github.com/nasa-jpl/www/issues/172#issuecomment-2354347969

Changes:
- differentiates between router and regular links in `NavSecondary` (this was breaking the anchor links because everything was being rendered as a router link)
- adds a max height and `overflow-y-auto` to `NavJumpMenu` items.
## Instructions to test

- Anchor links: Easiest to test within the www app. Storybook won't be accurate as we use a mock component for Nuxt Link, so you won't notice any differences in Storybook.
- Long NavJumpMenu items
  - `make vue-storybook`
  - View http://localhost:6006/?path=/story/navigation-jump-menu--extra-long

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
