### PR TITLE
fix: EDU BlockRichTable adjustments

### DIFF
--- a/packages/common/src/scss/components/_BlockRichTable.scss
+++ b/packages/common/src/scss/components/_BlockRichTable.scss
@@ -23,4 +23,11 @@
       @apply p-3 lg:p-5 align-top;
     }
   }
+  .BlockImageStandard,
+  .BlockText {
+    @apply min-w-[12rem] lg:min-w-[15rem];
+    .caption-area {
+      @apply pt-2;
+    }
+  }
 }

--- a/packages/vue/src/components/BlockRichTable/BlockRichTable.stories.js
+++ b/packages/vue/src/components/BlockRichTable/BlockRichTable.stories.js
@@ -72,3 +72,97 @@ export const BaseStory = {
     table: BlockRichTableData
   }
 }
+export const MixedColumnWidths = {
+  args: {
+    table: {
+      blockType: 'RichTableBlock',
+      tableCaption:
+        'Ut dapibus cursus quam, non dapibus diam pellentesque ac. Maecenas ultrices porta dui eget placerat. Curabitur ornare congue interdum.',
+      tableContent: {
+        tableHead: [
+          [
+            {
+              text: 'Image'
+            },
+            {
+              text: 'Type'
+            },
+            {
+              text: 'Description'
+            }
+          ]
+        ],
+        tableBody: [
+          [
+            {
+              ...BlockImageData,
+              caption: '<p>Custom ImageCaption</p>',
+              displayCaption: true,
+              blockType: 'ImageBlock'
+            },
+            {
+              blockType: 'CharBlock',
+              value: 'Internal'
+            },
+            {
+              blockType: 'RichTextBlock',
+              value:
+                '<p>Lorem ipsum <a href="/missions/test-mission/">dolor</a> sit amet, consectetur adipiscing elit. Quisque vitae justo quis justo malesuada molestie. Cras sed tincidunt dui.</p>\n'
+            }
+          ],
+          [
+            {
+              ...BlockImageData,
+              caption: '<p>Custom ImageCaption</p>',
+              displayCaption: true,
+              blockType: 'ImageBlock'
+            },
+            {
+              blockType: 'CharBlock',
+              value: 'External'
+            },
+            {
+              blockType: 'RichTextBlock',
+              value:
+                '<p>Morbi pretium, massa non convallis facilisis, lectus eros vulputate turpis, et imperdiet eros metus eu enim. Cras consequat iaculis leo eget auctor. Sed bibendum, nulla vel ultricies aliquam, augue mauris sagittis massa, nec malesuada massa justo id sem. In hac habitasse platea dictumst. Sed ullamcorper bibendum libero vitae pellentesque.</p>\n'
+            }
+          ],
+          [
+            {
+              ...BlockImageData,
+              caption: '<p>Custom ImageCaption</p>',
+              displayCaption: false,
+              blockType: 'ImageBlock'
+            },
+            {
+              blockType: 'CharBlock',
+              value: 'N/A'
+            },
+            {
+              blockType: 'RichTextBlock',
+              value:
+                '<p>Maecenas vel dapibus ligula, pretium <a href="#">dictum est</a>. Proin venenatis massa vulputate <strong>est rhoncus</strong>, sed ornare ex sagittis. Donec iaculis magna in rhoncus malesuada.</p>\n'
+            }
+          ],
+          [
+            {
+              ...BlockImageData,
+              caption: '<p>Custom ImageCaption</p>',
+              displayCaption: true,
+              blockType: 'ImageBlock'
+            },
+            {
+              blockType: 'CharBlock',
+              value: 'Internal'
+            },
+            {
+              blockType: 'RichTextBlock',
+              value:
+                '<p>Lorem ipsum <a href="/missions/test-mission/">dolor</a> sit amet, consectetur adipiscing elit. Quisque vitae justo quis justo malesuada molestie. Cras sed tincidunt dui.</p>\n'
+            }
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/packages/vue/src/components/BlockRichTable/BlockRichTable.vue
+++ b/packages/vue/src/components/BlockRichTable/BlockRichTable.vue
@@ -33,7 +33,7 @@ export default defineComponent({
               v-for="(headCell, headIndex) in table.tableContent.tableHead[0]"
               :key="headIndex"
               scope="col"
-              class="min-w-[12rem] bg-jpl-blue-darker edu:bg-jpl-violet-darker text-subtitle text-white border-gray-light-mid lg:p-5 p-3 border-b"
+              class="min-w-[6rem] bg-jpl-blue-darker edu:bg-jpl-violet-darker text-subtitle text-white border-gray-light-mid lg:p-5 p-3 border-b"
             >
               {{ headCell.text }}
             </th>
@@ -47,7 +47,7 @@ export default defineComponent({
             <td
               v-for="(cell, cellIndex) in row"
               :key="cellIndex"
-              class="min-w-[12rem] bg-white text-gray-dark border-gray-light-mid"
+              class="min-w-[6rem] bg-white text-gray-dark border-gray-light-mid"
             >
               <template v-if="cell.blockType === 'CharBlock'">
                 <p class="">

--- a/packages/vue/src/components/BlockRichTable/BlockRichTable.vue
+++ b/packages/vue/src/components/BlockRichTable/BlockRichTable.vue
@@ -33,7 +33,7 @@ export default defineComponent({
               v-for="(headCell, headIndex) in table.tableContent.tableHead[0]"
               :key="headIndex"
               scope="col"
-              class="min-w-[12rem] bg-jpl-blue-darker edu:bg-jpl-teal-dark text-subtitle text-white border-gray-light-mid lg:p-5 p-3 border-b"
+              class="min-w-[12rem] bg-jpl-blue-darker edu:bg-jpl-violet-darker text-subtitle text-white border-gray-light-mid lg:p-5 p-3 border-b"
             >
               {{ headCell.text }}
             </th>


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses feedback:
- https://github.com/nasa-jpl/www/issues/171#issuecomment-2370104633

Changes:
- Changes EDU BlockRichTable header row to use `bg-jpl-violet-darker`
- Modifies min-width rules in BlockRichTable and nested Blocks within to better handle multiple columns

## Instructions to test

Check the chromatic Storybook: https://668c47cbeb95392cd79c3c0d-kzqmnpjhzk.chromatic.com/?path=/story/components-blocks-blockrichtable--mixed-column-widths&globals=theme:ThemeEdu

Or test locally:

1. `make vue-storybook`
2. View http://localhost:6006/?path=/story/components-blocks-blockrichtable--mixed-column-widths&globals=theme:ThemeEdu


## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
