### PR TITLE
Feature/edu collections block link card

### DIFF
--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
@@ -258,3 +258,74 @@ export const LargeEduExplainerArticle = {
     }
   }
 }
+export const EduCollection = {
+  decorators: [
+    () => ({
+      template: `<div id="storyDecorator" class="relative grid grid-cols-2 gap-3"><story/></div>`
+    })
+  ],
+  args: {
+    ...BlockLinkCardData,
+    specialStyles: true,
+    data: {
+      page: {
+        __typename: 'EDUCollectionsDetailPage',
+        ...BlockLinkCardData.data,
+        summary:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse mattis auctor magna. Quisque molestie ex metus, et aliquet nunc porttitor nec. Donec imperdiet quam dolor, ut iaculis justo ornare non. Proin finibus nulla ut lorem molestie sagittis quis ut nulla. Sed sit amet dui consectetur, aliquam tortor nec, pulvinar libero.',
+        primarySubject: {
+          subject: 'Engineering'
+        },
+        gradeLevels: [
+          { gradeLevel: 'All Ages' },
+          { gradeLevel: 'K' },
+          { gradeLevel: '1' },
+          { gradeLevel: '2' },
+          { gradeLevel: '5' },
+          { gradeLevel: '6' },
+          { gradeLevel: '7' },
+          { gradeLevel: '8' }
+        ],
+        time: {
+          time: '1-2 hrs'
+        }
+      }
+    }
+  }
+}
+export const EduCollectionLarge = {
+  decorators: [
+    () => ({
+      template: `<div id="storyDecorator" class="relative grid grid-cols-2 gap-3"><story/></div>`
+    })
+  ],
+  args: {
+    ...BlockLinkCardData,
+    size: 'lg',
+    specialStyles: true,
+    data: {
+      page: {
+        __typename: 'EDUCollectionsDetailPage',
+        ...BlockLinkCardData.data,
+        summary:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse mattis auctor magna. Quisque molestie ex metus, et aliquet nunc porttitor nec. Donec imperdiet quam dolor, ut iaculis justo ornare non. Proin finibus nulla ut lorem molestie sagittis quis ut nulla. Sed sit amet dui consectetur, aliquam tortor nec, pulvinar libero.',
+        primarySubject: {
+          subject: 'Engineering'
+        },
+        gradeLevels: [
+          { gradeLevel: 'All Ages' },
+          { gradeLevel: 'K' },
+          { gradeLevel: '1' },
+          { gradeLevel: '2' },
+          { gradeLevel: '5' },
+          { gradeLevel: '6' },
+          { gradeLevel: '7' },
+          { gradeLevel: '8' }
+        ],
+        time: {
+          time: '1-2 hrs'
+        }
+      }
+    }
+  }
+}

--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
@@ -266,6 +266,7 @@ export const EduCollection = {
   ],
   args: {
     ...BlockLinkCardData,
+    size: 'sm',
     specialStyles: true,
     data: {
       page: {
@@ -294,11 +295,6 @@ export const EduCollection = {
   }
 }
 export const EduCollectionLarge = {
-  decorators: [
-    () => ({
-      template: `<div id="storyDecorator" class="relative grid grid-cols-2 gap-3"><story/></div>`
-    })
-  ],
   args: {
     ...BlockLinkCardData,
     size: 'lg',

--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
@@ -267,7 +267,7 @@ export const EduCollection = {
   args: {
     ...BlockLinkCardData,
     size: 'sm',
-    specialStyles: true,
+    useFeaturedStyles: true,
     data: {
       page: {
         __typename: 'EDUCollectionsDetailPage',
@@ -298,7 +298,7 @@ export const EduCollectionLarge = {
   args: {
     ...BlockLinkCardData,
     size: 'lg',
-    specialStyles: true,
+    useFeaturedStyles: true,
     data: {
       page: {
         __typename: 'EDUCollectionsDetailPage',

--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
@@ -1,10 +1,11 @@
 <template>
   <div v-if="theItem">
-    <template v-if="metadataType === 'EDUCollectionsDetailPage' && size === 'lg' && specialStyles">
+    <template v-if="metadataType === 'EDUCollectionsDetailPage' && specialStyles">
       <BlockLinkCardCollectionLg
         :the-item="theItem as EduResourceCardObject"
         :metadata-type="metadataType"
         :metadata-attrs="metadataAttrs"
+        :size="size"
       />
     </template>
     <template v-else>

--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
@@ -1,157 +1,170 @@
 <template>
-  <BaseLink
-    v-if="theItem"
-    variant="none"
-    :to="theItem.url ? theItem.url : undefined"
-    :href="theItem.externalLink ? theItem.externalLink : undefined"
-    class="BlockLinkCard group"
-    :link-class="`block ${small ? 'pb-3' : 'pb-5'} ${large ? 'sm:flex flex-row border-b border-gray-light-mid pb-5 mb-5' : ''}`"
-    external-target-blank
-  >
-    <BaseImagePlaceholder
-      :aspect-ratio="large ? '3:2' : '16:9'"
-      class="bg-gray-dark h-full relative overflow-hidden mb-6"
-      :class="{ 'lg:mb-10': medium, 'sm:w-1/3 lg:mb-0': large }"
-      dark-mode
-      no-logo
-    >
-      <BaseImage
-        v-if="theItem.thumbnailImage && theItem.thumbnailImage.src"
-        :src="theItem.thumbnailImage.src.url"
-        :width="theItem.thumbnailImage.src.width"
-        :height="theItem.thumbnailImage.src.height"
-        alt=""
-        object-fit-class="cover"
-        image-class="can-hover:group-hover:delay-200 can-hover:group-hover:scale-100 absolute top-0 left-0 w-full transition-all duration-200 ease-in transform scale-105"
-        loading="lazy"
+  <div v-if="theItem">
+    <template v-if="metadataType === 'EDUCollectionsDetailPage' && size === 'lg' && specialStyles">
+      <BlockLinkCardCollectionLg
+        :the-item="theItem as EduResourceCardObject"
+        :metadata-type="metadataType"
+        :metadata-attrs="metadataAttrs"
       />
-      <div v-else></div>
-      <CalendarChip
-        v-if="
-          showCalendarChip &&
-          themeStore.isEdu &&
-          ((theItem as EventCardObject).startDate || (theItem as EventCardObject).ongoing)
-        "
-        :start-date="(theItem as EventCardObject).startDate"
-        :end-date="(theItem as EventCardObject).endDate"
-        :ongoing="(theItem as EventCardObject).ongoing"
-      />
-    </BaseImagePlaceholder>
+    </template>
+    <template v-else>
+      <BaseLink
+        v-if="theItem"
+        variant="none"
+        :to="theItem.url ? theItem.url : undefined"
+        :href="theItem.externalLink ? theItem.externalLink : undefined"
+        class="BlockLinkCard group"
+        :link-class="`block ${small ? 'pb-3' : 'pb-5'} ${large ? 'sm:flex flex-row border-b border-gray-light-mid pb-5 mb-5' : ''}`"
+        external-target-blank
+      >
+        <BaseImagePlaceholder
+          :aspect-ratio="large ? '3:2' : '16:9'"
+          class="bg-gray-dark h-full relative overflow-hidden mb-6"
+          :class="{ 'lg:mb-10': medium, 'sm:w-1/3 lg:mb-0': large }"
+          dark-mode
+          no-logo
+        >
+          <BaseImage
+            v-if="theItem.thumbnailImage && theItem.thumbnailImage.src"
+            :src="theItem.thumbnailImage.src.url"
+            :width="theItem.thumbnailImage.src.width"
+            :height="theItem.thumbnailImage.src.height"
+            alt=""
+            object-fit-class="cover"
+            image-class="can-hover:group-hover:delay-200 can-hover:group-hover:scale-100 absolute top-0 left-0 w-full transition-all duration-200 ease-in transform scale-105"
+            loading="lazy"
+          />
+          <div v-else></div>
+          <CalendarChip
+            v-if="
+              showCalendarChip &&
+              themeStore.isEdu &&
+              ((theItem as EventCardObject).startDate || (theItem as EventCardObject).ongoing)
+            "
+            :start-date="(theItem as EventCardObject).startDate"
+            :end-date="(theItem as EventCardObject).endDate"
+            :ongoing="(theItem as EventCardObject).ongoing"
+          />
+        </BaseImagePlaceholder>
 
-    <div
-      class="BlockLinkCard__CardContent transition-translate can-hover:group-hover:delay-200 duration-200 ease-in transform ThemeVariantLight"
-      :class="contentClasses"
-    >
-      <template v-if="metadataAttrs">
-        <BasePill
-          :class="{ 'mb-2': !large, 'mb-4': large }"
-          size="sm"
-          :content-type="metadataType"
-          :text="(theItem as EventCardObject).eventType"
-        />
-      </template>
-      <template
-        v-else-if="themeStore.isEdu && theItem.parent?.title && theItem.parent?.title !== 'EDU'"
-      >
-        <div class="flex flex-wrap">
-          <p
-            class="text-subtitle"
-            :class="small ? 'mb-2' : 'mb-4'"
+        <div
+          class="BlockLinkCard__CardContent transition-translate can-hover:group-hover:delay-200 duration-200 ease-in transform ThemeVariantLight"
+          :class="contentClasses"
+        >
+          <template v-if="metadataAttrs">
+            <BasePill
+              :class="{ 'mb-2': !large, 'mb-4': large }"
+              size="sm"
+              :content-type="metadataType"
+              :text="(theItem as EventCardObject).eventType"
+            />
+          </template>
+          <template
+            v-else-if="themeStore.isEdu && theItem.parent?.title && theItem.parent?.title !== 'EDU'"
           >
-            <span class="edu:text-primary ThemeVariantLight">
-              {{ (theItem as Card).parent?.title }}
-            </span>
-          </p>
-        </div>
-      </template>
-      <template v-else>
-        <div class="flex flex-wrap">
-          <p
-            v-if="theItem.label || ((theItem as EventCardObject).startDate && !themeStore.isEdu)"
-            class="text-subtitle divide-gray-mid flex divide-x"
-            :class="small ? 'mb-2' : 'mb-4'"
-          >
-            <span
-              v-if="theItem.label"
-              class="edu:text-primary ThemeVariantLight"
-              :class="{ 'pr-2': (theItem as EventCardObject).startDate && !themeStore.isEdu }"
-            >
-              {{ theItem.label }}
-            </span>
-            <span
-              v-if="(theItem as EventCardObject).startDate && !themeStore.isEdu"
-              :class="{ 'text-gray-mid-dark pl-2': theItem.label }"
-            >
-              {{ formattedEventDates }}
-            </span>
-            <span class="sr-only">.</span>
-          </p>
-        </div>
-      </template>
+            <div class="flex flex-wrap">
+              <p
+                class="text-subtitle"
+                :class="small ? 'mb-2' : 'mb-4'"
+              >
+                <span class="edu:text-primary ThemeVariantLight">
+                  {{ (theItem as Card).parent?.title }}
+                </span>
+              </p>
+            </div>
+          </template>
+          <template v-else>
+            <div class="flex flex-wrap">
+              <p
+                v-if="
+                  theItem.label || ((theItem as EventCardObject).startDate && !themeStore.isEdu)
+                "
+                class="text-subtitle divide-gray-mid flex divide-x"
+                :class="small ? 'mb-2' : 'mb-4'"
+              >
+                <span
+                  v-if="theItem.label"
+                  class="edu:text-primary ThemeVariantLight"
+                  :class="{ 'pr-2': (theItem as EventCardObject).startDate && !themeStore.isEdu }"
+                >
+                  {{ theItem.label }}
+                </span>
+                <span
+                  v-if="(theItem as EventCardObject).startDate && !themeStore.isEdu"
+                  :class="{ 'text-gray-mid-dark pl-2': theItem.label }"
+                >
+                  {{ formattedEventDates }}
+                </span>
+                <span class="sr-only">.</span>
+              </p>
+            </div>
+          </template>
 
-      <component
-        :is="headingLevel || 'p'"
-        class="text-gray-dark text-xl font-medium leading-tight tracking-tight edu:font-extrabold"
-        :class="{ 'lg:text-3xl': !small }"
-      >
-        {{ theItem.title }}
-      </component>
-      <p
-        v-if="(theItem as EventCardObject).targetAudience"
-        :class="{ 'mt-1': !large, 'mt-4': large }"
-      >
-        <strong>Target Audience:</strong> {{ (theItem as EventCardObject).targetAudience }}
-      </p>
-      <p
-        v-if="theItem.date && !themeStore.isEdu"
-        class="text-gray-mid-dark"
-        :class="{ 'mt-2': !large, 'mt-4': large }"
-      >
-        {{ theItem.date }}
-      </p>
-      <p
-        v-if="large && theItem.summary"
-        class="mt-4 text-gray-mid-dark"
-        :class="{
-          'line-clamp-2 sm:line-clamp-1 lg:line-clamp-2 xl:line-clamp-3': themeStore.isEdu
-        }"
-      >
-        {{ theItem.summary }}
-      </p>
-      <p
-        v-if="theItem.date && themeStore.isEdu"
-        class="text-gray-mid-dark mt-2"
-        :class="{ 'mt-2': !large, 'mt-4': large }"
-      >
-        {{ theItem.date }}
-      </p>
-      <div
-        v-if="metadataAttrs"
-        :class="{ 'mt-4': large, 'mt-2 mb-1': medium, 'mt-1 mb-0': small }"
-      >
-        <MetadataEvent
-          v-if="metadataType === 'EDUEventPage'"
-          :event="theItem"
-          :show-time="large"
-          compact
-        />
-        <MetadataEduResource
-          v-else-if="metadataAttrs.type === 'resource'"
-          :resource="theItem as EduResourceCardObject"
-          :variant="metadataAttrs.icons"
-          :show-time="true"
-          compact
-        />
-      </div>
-    </div>
-    <div
-      v-if="!large"
-      class="BlockLinkCard__CardArrow ThemeVariantLight can-hover:block can-hover:-ml-3 can-hover:group-hover:delay-200 can-hover:opacity-0 can-hover:group-hover:ml-0 can-hover:group-hover:opacity-100 hidden -mt-1 text-2xl leading-normal transition-all duration-200 ease-in"
-      :class="metadataAttrs ? `text-${metadataAttrs.icons}` : 'text-primary'"
-    >
-      <IconArrow />
-    </div>
-  </BaseLink>
+          <component
+            :is="headingLevel || 'p'"
+            class="text-gray-dark text-xl font-medium leading-tight tracking-tight edu:font-extrabold"
+            :class="{ 'lg:text-3xl': !small }"
+          >
+            {{ theItem.title }}
+          </component>
+          <p
+            v-if="(theItem as EventCardObject).targetAudience"
+            :class="{ 'mt-1': !large, 'mt-4': large }"
+          >
+            <strong>Target Audience:</strong> {{ (theItem as EventCardObject).targetAudience }}
+          </p>
+          <p
+            v-if="theItem.date && !themeStore.isEdu"
+            class="text-gray-mid-dark"
+            :class="{ 'mt-2': !large, 'mt-4': large }"
+          >
+            {{ theItem.date }}
+          </p>
+          <p
+            v-if="large && theItem.summary"
+            class="mt-4 text-gray-mid-dark"
+            :class="{
+              'line-clamp-2 sm:line-clamp-1 lg:line-clamp-2 xl:line-clamp-3': themeStore.isEdu
+            }"
+          >
+            {{ theItem.summary }}
+          </p>
+          <p
+            v-if="theItem.date && themeStore.isEdu"
+            class="text-gray-mid-dark"
+            :class="{ 'mt-2': !large, 'mt-4': large }"
+          >
+            {{ theItem.date }}
+          </p>
+          <div
+            v-if="metadataAttrs"
+            :class="{ 'mt-4': large, 'mt-2 mb-1': medium, 'mt-1 mb-0': small }"
+          >
+            <MetadataEvent
+              v-if="metadataType === 'EDUEventPage'"
+              :event="theItem"
+              :show-time="large"
+              compact
+            />
+            <MetadataEduResource
+              v-else-if="metadataAttrs.type === 'resource'"
+              :resource="theItem as EduResourceCardObject"
+              :variant="metadataAttrs.icons"
+              :show-time="true"
+              compact
+            />
+          </div>
+        </div>
+        <div
+          v-if="!large"
+          class="BlockLinkCard__CardArrow ThemeVariantLight can-hover:block can-hover:-ml-3 can-hover:group-hover:delay-200 can-hover:opacity-0 can-hover:group-hover:ml-0 can-hover:group-hover:opacity-100 hidden -mt-1 text-2xl leading-normal transition-all duration-200 ease-in"
+          :class="metadataAttrs ? `text-${metadataAttrs.icons}` : 'text-primary'"
+        >
+          <IconArrow />
+        </div>
+      </BaseLink>
+    </template>
+  </div>
 </template>
 
 <script lang="ts">
@@ -167,6 +180,7 @@ import BaseLink from './../BaseLink/BaseLink.vue'
 import BaseImage from './../BaseImage/BaseImage.vue'
 import BaseImagePlaceholder from './../BaseImagePlaceholder/BaseImagePlaceholder.vue'
 import BasePill from './../BasePill/BasePill.vue'
+import BlockLinkCardCollectionLg from './../BlockLinkCard/BlockLinkCardCollectionLg.vue'
 import CalendarChip from './../CalendarChip/CalendarChip.vue'
 import MetadataEvent from './../MetadataEvent/MetadataEvent.vue'
 import MetadataEduResource from './../MetadataEduResource/MetadataEduResource.vue'
@@ -182,7 +196,8 @@ export default defineComponent({
     BasePill,
     CalendarChip,
     MetadataEvent,
-    MetadataEduResource
+    MetadataEduResource,
+    BlockLinkCardCollectionLg
   },
   props: {
     data: {
@@ -264,6 +279,10 @@ export default defineComponent({
       default: undefined
     },
     showCalendarChip: {
+      type: Boolean,
+      default: false
+    },
+    specialStyles: {
       type: Boolean,
       default: false
     }

--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="theItem">
-    <template v-if="metadataType === 'EDUCollectionsDetailPage' && specialStyles">
+    <template v-if="metadataType === 'EDUCollectionsDetailPage' && useFeaturedStyles">
       <BlockLinkCardCollectionLg
         :the-item="theItem as EduResourceCardObject"
         :metadata-type="metadataType"
@@ -283,7 +283,7 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
-    specialStyles: {
+    useFeaturedStyles: {
       type: Boolean,
       default: false
     }

--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCardCollectionLg.vue
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCardCollectionLg.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactive } from 'vue'
+import { computed, reactive } from 'vue'
 import type { EduResourceCardObject } from '../../interfaces'
 import type { HeadingLevel } from './../BaseHeading/BaseHeading.vue'
 import BaseLink from './../BaseLink/BaseLink.vue'
@@ -13,6 +13,7 @@ interface BlockLinkCardCollectionLgProps {
   metadataType?: string
   metadataAttrs?: any
   headingLevel?: HeadingLevel
+  size?: string
 }
 
 // define props
@@ -20,10 +21,15 @@ const props = withDefaults(defineProps<BlockLinkCardCollectionLgProps>(), {
   theItem: undefined,
   metadataType: undefined,
   metadataAttrs: undefined,
-  headingLevel: undefined
+  headingLevel: undefined,
+  size: undefined
 })
 
-const { theItem, metadataType, metadataAttrs, headingLevel } = reactive(props)
+const { theItem, metadataType, metadataAttrs, headingLevel, size } = reactive(props)
+
+const isSmall = computed(() => {
+  return size === 'sm'
+})
 </script>
 
 <template>
@@ -33,11 +39,16 @@ const { theItem, metadataType, metadataAttrs, headingLevel } = reactive(props)
     :to="theItem.url ? theItem.url : undefined"
     :href="theItem.externalLink ? theItem.externalLink : undefined"
     class="BlockLinkCardCollectionLg group bg-stars bg-primary-dark"
-    link-class="block sm:flex flex-row mb-8 relative"
+    :link-class="`block mb-8 relative ${isSmall ? 'flex flex-col' : 'sm:flex flex-row'}`"
     external-target-blank
   >
     <BaseImagePlaceholder
-      class="bg-gray-dark h-full relative sm:absolute sm:top-0 sm:right-0 sm:bottom:0 overflow-hidden mb-6 sm:w-1/3 lg:mb-0 order-1 sm:order-2 z-20 aspect-ratio-three-two sm:aspect-ratio-one-one"
+      class="bg-gray-dark h-full relative overflow-hidden mb-6 z-20"
+      :class="{
+        'aspect-ratio-sixteen-nine': isSmall,
+        'sm:absolute sm:top-0 sm:right-0 sm:bottom:0 sm:w-1/3 lg:mb-0 order-1 sm:order-2 aspect-ratio-three-two sm:aspect-ratio-one-one':
+          !isSmall
+      }"
       dark-mode
       no-logo
     >
@@ -54,7 +65,11 @@ const { theItem, metadataType, metadataAttrs, headingLevel } = reactive(props)
       <div v-else></div>
     </BaseImagePlaceholder>
     <div
-      class="BlockLinkCard__CardContent px-6 pb-6 sm:pt-6 lg:px-12 lg:py-10 can-hover:group-hover:delay-200 ThemeVariantLight sm:w-2/3 order-2 sm:order-1"
+      class="BlockLinkCard__CardContent can-hover:group-hover:delay-200 ThemeVariantLight"
+      :class="{
+        'px-4 pb-4': isSmall,
+        'px-6 pb-6 sm:pt-6 lg:px-12 lg:py-10 sm:w-2/3 order-2 sm:order-1': !isSmall
+      }"
     >
       <div
         class="absolute z-0 inset-0 bg-gradient-to-r from-transparent-black-75 to-transparent"
@@ -62,7 +77,10 @@ const { theItem, metadataType, metadataAttrs, headingLevel } = reactive(props)
       <div class="relative z-10">
         <template v-if="metadataAttrs">
           <BasePill
-            class="mb-4"
+            :class="{
+              'mb-2': isSmall,
+              'mb-4': !isSmall
+            }"
             size="sm"
             :content-type="metadataType"
           />
@@ -70,19 +88,25 @@ const { theItem, metadataType, metadataAttrs, headingLevel } = reactive(props)
 
         <component
           :is="headingLevel || 'p'"
-          class="text-white text-xl font-medium leading-tight tracking-tight edu:font-extrabold lg:text-3xl"
+          class="text-white text-xl font-medium leading-tight tracking-tight edu:font-extrabold"
+          :class="{
+            'lg:text-3xl': !isSmall
+          }"
         >
           {{ theItem.title }}
         </component>
         <p
-          v-if="theItem.summary"
+          v-if="theItem.summary && !isSmall"
           class="mt-4 text-white line-clamp-2 sm:line-clamp-1 lg:line-clamp-2 xl:line-clamp-3"
         >
           {{ theItem.summary }}
         </p>
         <div
           v-if="metadataAttrs"
-          class="mt-4"
+          :class="{
+            'mt-1': isSmall,
+            'mt-4': !isSmall
+          }"
         >
           <MetadataEduResource
             :resource="theItem"

--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCardCollectionLg.vue
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCardCollectionLg.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { reactive } from 'vue'
+import type { EduResourceCardObject } from '../../interfaces'
+import type { HeadingLevel } from './../BaseHeading/BaseHeading.vue'
+import BaseLink from './../BaseLink/BaseLink.vue'
+import BaseImage from './../BaseImage/BaseImage.vue'
+import BaseImagePlaceholder from './../BaseImagePlaceholder/BaseImagePlaceholder.vue'
+import BasePill from './../BasePill/BasePill.vue'
+import MetadataEduResource from './../MetadataEduResource/MetadataEduResource.vue'
+
+interface BlockLinkCardCollectionLgProps {
+  theItem?: EduResourceCardObject
+  metadataType?: string
+  metadataAttrs?: any
+  headingLevel?: HeadingLevel
+}
+
+// define props
+const props = withDefaults(defineProps<BlockLinkCardCollectionLgProps>(), {
+  theItem: undefined,
+  metadataType: undefined,
+  metadataAttrs: undefined,
+  headingLevel: undefined
+})
+
+const { theItem, metadataType, metadataAttrs, headingLevel } = reactive(props)
+</script>
+
+<template>
+  <BaseLink
+    v-if="theItem"
+    variant="none"
+    :to="theItem.url ? theItem.url : undefined"
+    :href="theItem.externalLink ? theItem.externalLink : undefined"
+    class="BlockLinkCardCollectionLg group bg-stars bg-primary-dark"
+    link-class="block sm:flex flex-row mb-8 relative"
+    external-target-blank
+  >
+    <BaseImagePlaceholder
+      class="bg-gray-dark h-full relative sm:absolute sm:top-0 sm:right-0 sm:bottom:0 overflow-hidden mb-6 sm:w-1/3 lg:mb-0 order-1 sm:order-2 z-20 aspect-ratio-three-two sm:aspect-ratio-one-one"
+      dark-mode
+      no-logo
+    >
+      <BaseImage
+        v-if="theItem.thumbnailImage && theItem.thumbnailImage.src"
+        :src="theItem.thumbnailImage.src.url"
+        :width="theItem.thumbnailImage.src.width"
+        :height="theItem.thumbnailImage.src.height"
+        alt=""
+        object-fit-class="cover"
+        image-class="can-hover:group-hover:delay-200 can-hover:group-hover:scale-[101%] absolute top-0 right-0 w-full transition-all duration-200 ease-in transform scale-105"
+        loading="lazy"
+      />
+      <div v-else></div>
+    </BaseImagePlaceholder>
+    <div
+      class="BlockLinkCard__CardContent px-6 pb-6 sm:pt-6 lg:px-12 lg:py-10 can-hover:group-hover:delay-200 ThemeVariantLight sm:w-2/3 order-2 sm:order-1"
+    >
+      <div
+        class="absolute z-0 inset-0 bg-gradient-to-r from-transparent-black-75 to-transparent"
+      ></div>
+      <div class="relative z-10">
+        <template v-if="metadataAttrs">
+          <BasePill
+            class="mb-4"
+            size="sm"
+            :content-type="metadataType"
+          />
+        </template>
+
+        <component
+          :is="headingLevel || 'p'"
+          class="text-white text-xl font-medium leading-tight tracking-tight edu:font-extrabold lg:text-3xl"
+        >
+          {{ theItem.title }}
+        </component>
+        <p
+          v-if="theItem.summary"
+          class="mt-4 text-white line-clamp-2 sm:line-clamp-1 lg:line-clamp-2 xl:line-clamp-3"
+        >
+          {{ theItem.summary }}
+        </p>
+        <div
+          v-if="metadataAttrs"
+          class="mt-4"
+        >
+          <MetadataEduResource
+            :resource="theItem"
+            :variant="metadataAttrs.icons"
+            compact
+          />
+        </div>
+      </div>
+    </div>
+  </BaseLink>
+</template>
+<style lang="scss">
+.BlockLinkCardCollectionLg {
+  .MetadataEduResource .MetadataEduResourceItem {
+    .MetadataEduResourceIcon {
+      @apply text-white;
+    }
+    span {
+      @apply text-white;
+    }
+  }
+}
+</style>

--- a/packages/vue/src/components/MetadataEduResource/MetadataEduResource.vue
+++ b/packages/vue/src/components/MetadataEduResource/MetadataEduResource.vue
@@ -11,7 +11,7 @@ interface MetadataEduResourceProps {
   resource: EduResourceCardObject
   compact?: boolean
   variant?: string
-  showTime: boolean
+  showTime?: boolean
 }
 
 // define props

--- a/packages/vue/src/components/SearchResultCard/SearchResultCard.vue
+++ b/packages/vue/src/components/SearchResultCard/SearchResultCard.vue
@@ -29,6 +29,7 @@
         }
       }"
       show-calendar-chip
+      special-styles
     />
     <EventCard
       v-else-if="isEvents"

--- a/packages/vue/src/components/SearchResultCard/SearchResultCard.vue
+++ b/packages/vue/src/components/SearchResultCard/SearchResultCard.vue
@@ -29,7 +29,7 @@
         }
       }"
       show-calendar-chip
-      special-styles
+      use-featured-styles
     />
     <EventCard
       v-else-if="isEvents"

--- a/packages/vue/src/components/SearchResultGridItem/SearchResultGridItem.vue
+++ b/packages/vue/src/components/SearchResultGridItem/SearchResultGridItem.vue
@@ -28,6 +28,7 @@
       :heading-level="headingLevel"
       size="sm"
       show-calendar-chip
+      special-styles
     />
     <BlockLinkCard
       v-else-if="typename === 'News'"

--- a/packages/vue/src/components/SearchResultGridItem/SearchResultGridItem.vue
+++ b/packages/vue/src/components/SearchResultGridItem/SearchResultGridItem.vue
@@ -28,7 +28,7 @@
       :heading-level="headingLevel"
       size="sm"
       show-calendar-chip
-      special-styles
+      use-featured-styles
     />
     <BlockLinkCard
       v-else-if="typename === 'News'"


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses feedback:
- https://github.com/nasa-jpl/www/issues/229#issuecomment-2316553924

Changes:
- Adds a nested component to `BlockLinkCard` that will only be in visible in search results for EDU Collections
- Styles include both list and grid search result layouts

## Instructions to test

Check chromatic:
1. List results: https://668c47cbeb95392cd79c3c0d-sxdljonzmd.chromatic.com/?path=/story/components-cards-blocklinkcard--edu-collection-large&globals=theme:ThemeEdu
2. Grid results: https://668c47cbeb95392cd79c3c0d-sxdljonzmd.chromatic.com/?path=/story/components-cards-blocklinkcard--edu-collection&globals=theme:ThemeEdu

Or test locally:
1. `make vue-storybook`
2. List results: http://localhost:6006/?path=/story/components-cards-blocklinkcard--edu-collection-large&globals=theme:ThemeEdu
3. Grid results: http://localhost:6006/?path=/story/components-cards-blocklinkcard--edu-collection&globals=theme:ThemeEdu

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
