### PR TITLE
fix: listing metadata for EDU News and External Links

### DIFF
--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
@@ -277,3 +277,31 @@ export const EduNewsItem = {
     size: 'sm'
   }
 }
+
+export const ExternalLink = {
+  decorators: [
+    () => ({
+      template: `<div id="storyDecorator" class="relative grid grid-cols-2 gap-3"><story/></div>`
+    })
+  ],
+  args: {
+    data: {
+      __typename: 'ExternalLinkCardWithDescription',
+      externalLink: 'https://nasa.gov',
+      title: 'External Link',
+      label: 'Dolor Sit',
+      summary:
+        'Cras rhoncus lorem condimentum tellus rhoncus dictum. Maecenas finibus nibh lorem, quis ornare est vulputate et. Nulla imperdiet ultrices est, ac mattis justo consequat sit amet.',
+      thumbnailImage: {
+        __typename: 'CustomImage',
+        src: {
+          __typename: 'CustomRendition',
+          url: 'https://picsum.photos/512/288',
+          width: '512',
+          height: '288'
+        }
+      }
+    },
+    headingLevel: 'h2'
+  }
+}

--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.stories.js
@@ -258,3 +258,22 @@ export const LargeEduExplainerArticle = {
     }
   }
 }
+
+export const EduNewsItem = {
+  decorators: [
+    () => ({
+      template: `<div id="storyDecorator" class="relative grid grid-cols-2 gap-3"><story/></div>`
+    })
+  ],
+  args: {
+    ...BlockLinkCardData,
+    data: {
+      page: {
+        ...BlockLinkCardData.data,
+        __typename: 'EDUNewsPage'
+      }
+    },
+    headingLevel: 'h2',
+    size: 'sm'
+  }
+}

--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
@@ -93,6 +93,12 @@
             </span>
             <span class="sr-only">.</span>
           </p>
+          <template v-if="theItem.externalLink">
+            <IconExternal
+              class="text-primary ml-2"
+              :class="{ 'text-sm mt-1px': small, '-mt-1px': medium, '-mt-.5': large }"
+            />
+          </template>
         </div>
       </template>
 
@@ -170,6 +176,7 @@ import { useThemeStore } from '../../store/theme'
 import { mixinFormatEventDates } from './../../utils/mixins'
 import type { HeadingLevel } from './../BaseHeading/BaseHeading.vue'
 import IconArrow from './../Icons/IconArrow.vue'
+import IconExternal from './../Icons/IconExternal.vue'
 import BaseLink from './../BaseLink/BaseLink.vue'
 import BaseImage from './../BaseImage/BaseImage.vue'
 import BaseImagePlaceholder from './../BaseImagePlaceholder/BaseImagePlaceholder.vue'
@@ -183,6 +190,7 @@ export default defineComponent({
   name: 'BlockLinkCard',
   components: {
     IconArrow,
+    IconExternal,
     BaseLink,
     BaseImage,
     BaseImagePlaceholder,

--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
@@ -49,10 +49,17 @@
           :content-type="metadataType"
           :text="(theItem as EventCardObject).eventType"
         />
+        <template v-if="metadataType === 'EDUNewsPage' && theItem.label">
+          <!-- include the topic label for EDU News -->
+          <span class="text-subtitle text-gray-mid-dark uppercase ThemeVariantLight pl-3">
+            {{ theItem.label }}
+          </span>
+        </template>
       </template>
       <template
         v-else-if="themeStore.isEdu && theItem.parent?.title && theItem.parent?.title !== 'EDU'"
       >
+        <!-- use parent page's title as the label for EDU Content cards, unless the EDU homepage is the parent -->
         <div class="flex flex-wrap">
           <p
             class="text-subtitle"

--- a/packages/vue/src/constants.ts
+++ b/packages/vue/src/constants.ts
@@ -1,6 +1,12 @@
 import type { PillDictionaryInterface } from './interfaces'
 
 export const eduMetadataDictionary: PillDictionaryInterface = {
+  EDUNewsPage: {
+    label: 'News',
+    variant: 'primary',
+    icons: 'primary',
+    type: undefined
+  },
   EDUEventPage: {
     label: 'Event',
     variant: 'primary',


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses feedback:
- https://github.com/nasa-jpl/www/issues/191#issuecomment-2322505407

Changes:
- Adds an external link icon next to the label for all External Link BlockLinkCards (including www)
- Adds both the news "pill" and topic label for EDU News items

## Instructions to test

Check Chromatic:
- External Link Card: https://668c47cbeb95392cd79c3c0d-ybyaghbiaa.chromatic.com/?path=/story/components-cards-blocklinkcard--external-link (you can switch between EDU and WWW themes in the top toolbar)
- EDU News Card: https://668c47cbeb95392cd79c3c0d-ybyaghbiaa.chromatic.com/?path=/story/components-cards-blocklinkcard--edu-news-item&globals=theme:ThemeEdu

Or test locally:

1. `make vue-storybook`
2. Check the following stories, and try changing the "size" attribute in controls
  - External link card: http://localhost:6006/?path=/story/components-cards-blocklinkcard--external-link&args=size:lg&globals=theme:ThemeEdu 
  - EDU News card: http://localhost:6006/?path=/story/components-cards-blocklinkcard--edu-news-item&globals=theme:ThemeEdu


## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
