### PR TITLE
fix: full bleed adjustments

### DIFF
--- a/packages/vue/src/components/BlockCardGrid/BlockCardGrid.stories.js
+++ b/packages/vue/src/components/BlockCardGrid/BlockCardGrid.stories.js
@@ -92,3 +92,6 @@ export const BaseStory = {
   name: 'BlockCardGrid',
   args: { cards: BlockCardGridData }
 }
+export const ThreeCards = {
+  args: { cards: BlockCardGridData.slice(0, 3) }
+}

--- a/packages/vue/src/components/BlockCardGrid/BlockCardGrid.vue
+++ b/packages/vue/src/components/BlockCardGrid/BlockCardGrid.vue
@@ -3,9 +3,7 @@
     v-if="cards"
     class="BlockCardGrid"
   >
-    <div
-      :class="`hidden md:grid md:grid-cols-2 lg:grid-cols-3 ${compact ? ' gap-5' : '3xl:grid-cols-4 gap-8'}`"
-    >
+    <div :class="computedClasses">
       <BlockCardGridItem
         v-for="(card, index) of cards"
         :key="`item-${index}`"
@@ -64,6 +62,23 @@ export default defineComponent({
     cards: {
       type: Array as PropType<CardGridItem[]>,
       default: undefined
+    }
+  },
+  computed: {
+    fourColumns() {
+      return this.cards && this.cards.length > 3
+    },
+    computedClasses() {
+      let classes = 'hidden md:grid md:grid-cols-2 lg:grid-cols-3'
+      if (this.compact) {
+        classes += ' gap-5'
+      } else {
+        classes += ' gap-8'
+      }
+      if (this.fourColumns) {
+        classes += ' xl:grid-cols-4'
+      }
+      return classes
     }
   }
 })

--- a/packages/vue/src/components/BlockImage/BlockImageFullBleed.vue
+++ b/packages/vue/src/components/BlockImage/BlockImageFullBleed.vue
@@ -109,34 +109,32 @@ export default defineComponent({
     v-if="theData"
     class="BlockImageFullBleed"
   >
-    <div class="bg-gray-light">
-      <div class="max-w-screen-3xl mx-auto">
-        <MixinFancybox
-          v-if="theData.src"
-          :src="theData.original || theData.src?.url"
-          :caption="theData.caption"
-          :credit="theData.credit"
-          :detail-url="customDetailUrl || theData.detailUrl"
+    <div class="max-w-screen-3xl mx-auto">
+      <MixinFancybox
+        v-if="theData.src"
+        :src="theData.original || theData.src?.url"
+        :caption="theData.caption"
+        :credit="theData.credit"
+        :detail-url="customDetailUrl || theData.detailUrl"
+      >
+        <BaseImagePlaceholder
+          :aspect-ratio="constrain ? '16:9' : 'none'"
+          :responsive-aspect-ratio="constrain ? 'lg:aspect-ratio-two-one' : ''"
+          dark-mode
         >
-          <BaseImagePlaceholder
-            :aspect-ratio="constrain ? '16:9' : 'none'"
-            :responsive-aspect-ratio="constrain ? 'lg:aspect-ratio-two-one' : ''"
-            dark-mode
-          >
-            <BaseImage
-              v-if="theData.src && theData.srcCropped"
-              :src="constrain ? theData.srcCropped.url : theData.src.url"
-              :srcset="theData.srcSet && !constrain ? theData.srcSet : theSrcSet"
-              :width="constrain ? theData.srcCropped.width : theData.src.width"
-              :height="constrain ? theData.srcCropped.height : theData.src.height"
-              :alt="theData.alt"
-              :image-class="!constrain ? 'w-full h-auto' : undefined"
-              :object-fit-class="constrain ? 'cover' : undefined"
-              loading="lazy"
-            />
-          </BaseImagePlaceholder>
-        </MixinFancybox>
-      </div>
+          <BaseImage
+            v-if="theData.src && theData.srcCropped"
+            :src="constrain ? theData.srcCropped.url : theData.src.url"
+            :srcset="theData.srcSet && !constrain ? theData.srcSet : theSrcSet"
+            :width="constrain ? theData.srcCropped.width : theData.src.width"
+            :height="constrain ? theData.srcCropped.height : theData.src.height"
+            :alt="theData.alt"
+            :image-class="!constrain ? 'w-full h-auto' : undefined"
+            :object-fit-class="constrain ? 'cover' : undefined"
+            loading="lazy"
+          />
+        </BaseImagePlaceholder>
+      </MixinFancybox>
     </div>
     <div
       v-if="data && hasCaptionArea"

--- a/packages/vue/src/components/HeroMedia/HeroMedia.vue
+++ b/packages/vue/src/components/HeroMedia/HeroMedia.vue
@@ -3,51 +3,49 @@
     v-if="image || video"
     class="HeroMedia"
   >
-    <div class="bg-gray-light">
-      <div class="vh-crop max-w-screen-3xl relative flex items-center mx-auto overflow-hidden">
-        <div class="hero">
-          <template v-if="theImageData">
-            <img
-              v-if="theImageData.src"
-              class="object-cover object-center w-full h-full"
-              :srcset="theSrcSet"
-              :src="theImageData.src.url"
-              :width="theImageData.src.width"
-              :height="theImageData.src.height"
-              :alt="theImageData.alt"
-              itemprop="image"
-              data-chromatic="ignore"
-            />
-          </template>
-          <template v-else-if="video">
-            <MixinVideoBg :video="video" />
-          </template>
-        </div>
-        <div
-          v-if="hasCaptionArea"
-          class="lg:hidden absolute bottom-0 left-0 w-full h-auto mx-auto print:hidden"
-        >
-          <button
-            class="bg-opacity-90 text-gray-dark flex items-center justify-center w-12 h-12 ml-auto bg-white cursor-pointer"
-            aria-label="Toggle caption"
-            @click="toggleCaption"
-          >
-            <IconInfo
-              v-show="!captionVisible"
-              class="text-xl"
-            />
-            <IconClose v-show="captionVisible" />
-          </button>
-        </div>
+    <div class="vh-crop max-w-screen-3xl relative flex items-center mx-auto overflow-hidden">
+      <div class="hero">
+        <template v-if="theImageData">
+          <img
+            v-if="theImageData.src"
+            class="object-cover object-center w-full h-full"
+            :srcset="theSrcSet"
+            :src="theImageData.src.url"
+            :width="theImageData.src.width"
+            :height="theImageData.src.height"
+            :alt="theImageData.alt"
+            itemprop="image"
+            data-chromatic="ignore"
+          />
+        </template>
+        <template v-else-if="video">
+          <MixinVideoBg :video="video" />
+        </template>
       </div>
-
       <div
         v-if="hasCaptionArea"
-        :class="captionVisibilityClass"
-        class="caption-area max-w-screen-3xl ThemeVariantGray bg-gray-light bg-opacity-90 lg:bg-opacity-100 ThemeVariantGray lg:block lg:pb-4 lg:px-3 xl:px-8 lg:pt-4 items-start p-4 mx-auto print:block"
+        class="lg:hidden absolute bottom-0 left-0 w-full h-auto mx-auto print:hidden"
       >
-        <BaseImageCaption :data="theImageData || customCaption" />
+        <button
+          class="bg-opacity-90 text-gray-dark flex items-center justify-center w-12 h-12 ml-auto bg-white cursor-pointer"
+          aria-label="Toggle caption"
+          @click="toggleCaption"
+        >
+          <IconInfo
+            v-show="!captionVisible"
+            class="text-xl"
+          />
+          <IconClose v-show="captionVisible" />
+        </button>
       </div>
+    </div>
+
+    <div
+      v-if="hasCaptionArea"
+      :class="captionVisibilityClass"
+      class="caption-area max-w-screen-3xl ThemeVariantGray bg-gray-light bg-opacity-90 lg:bg-opacity-100 ThemeVariantGray lg:block lg:pb-4 lg:px-3 xl:px-8 lg:pt-4 items-start p-4 mx-auto print:block"
+    >
+      <BaseImageCaption :data="theImageData || customCaption" />
     </div>
   </div>
 </template>

--- a/packages/vue/src/components/NavDesktopEdu/NavDesktopEdu.vue
+++ b/packages/vue/src/components/NavDesktopEdu/NavDesktopEdu.vue
@@ -12,7 +12,7 @@
     }"
   >
     <!-- navbar -->
-    <div class="header-bg z-10 max-w-screen-3xl absolute inset-0 mx-auto"></div>
+    <div class="header-bg z-10 absolute inset-0 mx-auto"></div>
     <div class="px-4">
       <div class="h-18 container flex items-center justify-between mx-auto">
         <!-- branding -->


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses feedback:
- https://github.com/nasa-jpl/www/issues/601#issue-2546642664

Changes:
- EDU NavDesktop will now expand to full-width
- Removed gray extenders in `HeroMedia` and `BlockImageFullBleed` site-wide
- Modified BlockCardGrid to only expand to four columns if there are at least four cards. I also changed the breakpoint for when this expands, as it's previous breakpoint didn't make much sense (its container wasn't changing size, just the viewport).

## Instructions to test

1. `make vue-storybook`
2. Full width EDU Nav: http://localhost:6006/?path=/story/navigation-headers-edu-navdesktopedu--base-story&globals=theme:ThemeEdu
3. Remove gray extenders:
    - View http://localhost:6006/?path=/story/components-blocks-blockimage--full-bleed
    - View http://localhost:6006/?path=/story/components-heroes-media-only--base-story
4. BlockCardGrid
    - Only three cards: http://localhost:6006/?path=/story/components-blocks-blockcardgrid--three-cards&globals=theme:ThemeEdu
    - Context-aware breakpoint for 4 columns:
      - View in Streamfield: http://localhost:6006/?path=/story/components-blocks-blockstreamfield--base-story (scroll down to the bottom)
      - View in Robotics template: http://localhost:6006/?path=/story/templates-www-pageroboticsdetail--template

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
