### PR TITLE
EDU: adjusting height of accordion filter groups to match non-accordions

### DIFF
--- a/packages/vue/src/components/SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue
+++ b/packages/vue/src/components/SearchFilterGroupAccordionItem/SearchFilterGroupAccordionItem.vue
@@ -41,10 +41,10 @@ const emit = defineEmits(['filterGroupAccordionItemOpened', 'filterGroupAccordio
 </script>
 <template>
   <div
-    class="SearchFilterGroupAccordionItem border-t pt-2.5"
+    class="SearchFilterGroupAccordionItem border-t pt-[0.4375rem]"
     :class="{
       '-open border-gray-light-mid  -mb-px': !isHidden,
-      'border-transparent mb-3': isHidden
+      'border-transparent mb-2.5': isHidden
     }"
   >
     <div class="SearchFilterGroupAccordionItemHeader flex flex-row w-full content-between">


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses feedback:
- https://github.com/nasa-jpl/www/issues/466#issuecomment-2357307577

Changes:
- modifies padding and margin around filter group accordions to match that of non-accordions

## Instructions to test

1. `make-vue-storybook`
2. View http://localhost:6006/?path=/story/components-search-searchfiltergroup--sub-filters
3. Inspect the filter items. Each should be a height of 32px.
![image](https://github.com/user-attachments/assets/31032fd0-c3b5-4b5f-a735-071f7d5aea99)


## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
