### PR TITLE
fix: rich text media on Student Projects

### DIFF
--- a/packages/vue/src/templates/edu/PageEduStudentProject/PageEduStudentProjectSection.vue
+++ b/packages/vue/src/templates/edu/PageEduStudentProject/PageEduStudentProjectSection.vue
@@ -188,18 +188,21 @@ const { heading, blocks, image, steps, stepsNumbering, text } = reactive(props)
     // intentionally overriding correction that occurs within ThemeVariantGray
     @apply text-jpl-red;
   }
-  .richtext-image {
-    &.right,
-    &.left {
-      @apply lg:max-w-md;
-    }
-    &.right {
-      @apply mr-0;
-    }
-    &.left {
-      @apply ml-0;
+  .LayoutHelper > div > .BlockText {
+    .richtext-image {
+      &.right,
+      &.left {
+        @apply lg:max-w-md;
+      }
+      &.right {
+        @apply mr-0;
+      }
+      &.left {
+        @apply ml-0;
+      }
     }
   }
+
   .PageEduStudentProjectStep__fullWidth {
     .LayoutHelper > div > .BlockText {
       p,


### PR DESCRIPTION
Follow up to:
- #643 
- https://github.com/nasa-jpl/www/issues/217#issuecomment-2372154363

Determined the issue was due to the more specific rule taking precedence (though this only occurred on the server)
