### PR TITLE
only showing IconExternal in BlockLinkCard for edu theme

### DIFF
--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
@@ -105,7 +105,7 @@
                 </span>
                 <span class="sr-only">.</span>
               </p>
-              <template v-if="theItem.externalLink">
+              <template v-if="theItem.externalLink && themeStore.isEdu">
                 <IconExternal
                   class="text-primary ml-2"
                   :class="{ 'text-sm mt-1px': small, '-mt-1px': medium, '-mt-.5': large }"


### PR DESCRIPTION
Limiting the newly added `IconExternal` in `BlockLinkCard` to the EDU theme to minimize potential impact on WWW. 