### PR TITLE
specifying what qualifies as an external link for EDU theme

### DIFF
--- a/packages/vue/src/components/BaseLink/BaseLink.vue
+++ b/packages/vue/src/components/BaseLink/BaseLink.vue
@@ -1,7 +1,10 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
+import { mapStores } from 'pinia'
+import { useThemeStore } from '../../store/theme'
 import { eventBus } from './../../utils/eventBus'
 import MixinAnimationCaret from './../MixinAnimationCaret/MixinAnimationCaret.vue'
+import { isEduExternalLink } from './../../utils/isEduExternalLink'
 
 interface Variants {
   [key: string]: string
@@ -111,6 +114,7 @@ export default defineComponent({
   },
   emits: ['linkClicked', 'specificLinkClicked'],
   computed: {
+    ...mapStores(useThemeStore),
     computedVariants(): Variants {
       if (this.usePrimaryColor) {
         return primaryColorVariants
@@ -127,10 +131,27 @@ export default defineComponent({
       }
       return classes
     },
+    isEduExternal(): boolean | string {
+      if (this.href) {
+        return isEduExternalLink(this.href)
+      }
+      return ''
+    },
+    isExternal(): boolean {
+      if (this.href) {
+        if (this.themeStore.isEdu && isEduExternalLink(this.href)) {
+          return true
+        } else if (!this.themeStore.isEdu) {
+          return true
+        }
+        return false
+      }
+      return false
+    },
     theTarget(): string | undefined {
       if (this.target) {
         return this.target
-      } else if (this.href && this.externalTargetBlank) {
+      } else if (this.isExternal && this.externalTargetBlank) {
         return '_blank'
       }
       return undefined

--- a/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
+++ b/packages/vue/src/components/BlockLinkCard/BlockLinkCard.vue
@@ -105,7 +105,13 @@
                 </span>
                 <span class="sr-only">.</span>
               </p>
-              <template v-if="theItem.externalLink && themeStore.isEdu">
+              <template
+                v-if="
+                  theItem.externalLink &&
+                  themeStore.isEdu &&
+                  isEduExternalLink(theItem.externalLink)
+                "
+              >
                 <IconExternal
                   class="text-primary ml-2"
                   :class="{ 'text-sm mt-1px': small, '-mt-1px': medium, '-mt-.5': large }"
@@ -188,6 +194,7 @@ import { defineComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useThemeStore } from '../../store/theme'
 import { mixinFormatEventDates } from './../../utils/mixins'
+import { isEduExternalLink } from './../../utils/isEduExternalLink'
 import type { HeadingLevel } from './../BaseHeading/BaseHeading.vue'
 import IconArrow from './../Icons/IconArrow.vue'
 import IconExternal from './../Icons/IconExternal.vue'
@@ -388,6 +395,11 @@ export default defineComponent({
             (this.theItem as EventCardObject).endDate
           )
         : undefined
+    }
+  },
+  methods: {
+    isEduExternalLink(url: string): boolean {
+      return isEduExternalLink(url)
     }
   }
 })

--- a/packages/vue/src/utils/isEduExternalLink.ts
+++ b/packages/vue/src/utils/isEduExternalLink.ts
@@ -1,0 +1,12 @@
+export const isEduExternalLink = (url: string): boolean => {
+  if (
+    url &&
+    (url.startsWith('/edu/') ||
+      url.startsWith('/edubeta/') ||
+      url.startsWith('https://www.jpl.nasa.gov/edu/') ||
+      url.startsWith('https://jpl.nasa.gov/edu/'))
+  ) {
+    return false
+  }
+  return true
+}


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses:
- https://github.com/nasa-jpl/www/issues/619

Changes:
- Adds a utility function that determines whether a string should be considered an external link in the EDU theme
- Uses this utility function in both `BlockLinkCard` and `BaseLink`

## Instructions to test

1. `make vue-storybook`
2. http://localhost:6006/?path=/story/components-cards-blocklinkcard--external-link&globals=theme:ThemeEdu (should show external link icon)
3. In the controls tab, change `data.externalLink` to `https://jpl.nasa.gov/edu/` or any of the strings that the new utility function checks for. Make sure the external link icon does not appear in those cases. Note, you may have to click on the Storybook "refresh" button in the storybook toolbar (not the browser toolbar) for the story to update.

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
