### PR TITLE
fixing inline display of video block heroes

### DIFF
--- a/packages/vue/src/components/HeroInlineMedia/HeroInlineMedia.vue
+++ b/packages/vue/src/components/HeroInlineMedia/HeroInlineMedia.vue
@@ -41,7 +41,6 @@ const { heroBlocks, constrain } = reactive(props)
     <BlockVideo
       v-else-if="heroBlocks[0].blockType === 'VideoBlock'"
       :data="heroBlocks[0]"
-      autoplay
     />
     <BaseImagePlaceholder
       v-else-if="heroBlocks[0].blockType === 'VideoEmbedBlock'"

--- a/packages/vue/src/templates/edu/PageEduExplainerArticle/PageEduExplainerArticle.vue
+++ b/packages/vue/src/templates/edu/PageEduExplainerArticle/PageEduExplainerArticle.vue
@@ -56,12 +56,9 @@ export default defineComponent({
       return false
     },
     heroInline(): boolean {
-      // heroes with interactive elements have special handling
       if (this.theHero && !this.heroTitle) {
-        // excludes VideoBlock as this will autoplay
-        if (this.theHero.blockType === 'VideoBlock') {
-          return false
-        } else if (
+        // heroes with interactive elements have special handling
+        if (
           this.data?.heroPosition === 'inline' ||
           this.theHero.blockType === 'CarouselBlock' ||
           this.theHero.blockType === 'IframeEmbedBlock' ||
@@ -70,6 +67,7 @@ export default defineComponent({
         ) {
           return true
         }
+        return false
       }
       return false
     },

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLesson.vue
@@ -113,12 +113,9 @@ const heroTitle = computed((): boolean => {
 })
 
 const heroInline = computed((): boolean => {
-  // heroes with interactive elements have special handling
   if (theHero.value && !heroTitle.value) {
-    // excludes VideoBlock as this will autoplay
-    if (theHero.value.blockType === 'VideoBlock') {
-      return false
-    } else if (
+    // heroes with interactive elements have special handling
+    if (
       data?.heroPosition === 'inline' ||
       theHero.value.blockType === 'CarouselBlock' ||
       theHero.value.blockType === 'IframeEmbedBlock' ||
@@ -127,6 +124,7 @@ const heroInline = computed((): boolean => {
     ) {
       return true
     }
+    return false
   }
   return false
 })

--- a/packages/vue/src/templates/edu/PageEduStudentProject/PageEduStudentProject.vue
+++ b/packages/vue/src/templates/edu/PageEduStudentProject/PageEduStudentProject.vue
@@ -92,12 +92,9 @@ const heroTitle = computed((): boolean => {
 })
 
 const heroInline = computed((): boolean => {
-  // heroes with interactive elements have special handling
   if (theHero.value && !heroTitle.value) {
-    // excludes VideoBlock as this will autoplay
-    if (theHero.value.blockType === 'VideoBlock') {
-      return false
-    } else if (
+    // heroes with interactive elements have special handling
+    if (
       data?.heroPosition === 'inline' ||
       theHero.value.blockType === 'CarouselBlock' ||
       theHero.value.blockType === 'IframeEmbedBlock' ||
@@ -106,6 +103,7 @@ const heroInline = computed((): boolean => {
     ) {
       return true
     }
+    return false
   }
   return false
 })

--- a/packages/vue/src/templates/edu/PageEduTeachableMoment/PageEduTeachableMoment.vue
+++ b/packages/vue/src/templates/edu/PageEduTeachableMoment/PageEduTeachableMoment.vue
@@ -52,12 +52,9 @@ const heroTitle = computed((): boolean => {
 })
 
 const heroInline = computed((): boolean => {
-  // heroes with interactive elements have special handling
   if (theHero.value && !heroTitle.value) {
-    // excludes VideoBlock as this will autoplay
-    if (theHero.value.blockType === 'VideoBlock') {
-      return false
-    } else if (
+    // heroes with interactive elements have special handling
+    if (
       data?.heroPosition === 'inline' ||
       theHero.value.blockType === 'CarouselBlock' ||
       theHero.value.blockType === 'IframeEmbedBlock' ||
@@ -66,6 +63,7 @@ const heroInline = computed((): boolean => {
     ) {
       return true
     }
+    return false
   }
   return false
 })


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Adds support for inline VideoBlock heroes on EDU templates.

## Instructions to test

<!-- Provide instructions on how a reviewer can verify your work. -->

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
