### PR TITLE
adding trailing slashes in BaseLink

### DIFF
--- a/packages/vue/src/components/BaseLink/BaseLink.vue
+++ b/packages/vue/src/components/BaseLink/BaseLink.vue
@@ -186,8 +186,8 @@ export default defineComponent({
     addTrailingSlash(path: string) {
       let filteredPath = path
       const isFilePath = () => {
-        const afterLashSlash = path.split('/').pop()
-        if (afterLashSlash && afterLashSlash.includes('.')) {
+        const afterLastSlash = path.split('/').pop()
+        if (afterLastSlash && afterLastSlash.includes('.')) {
           return true
         }
         return false

--- a/packages/vue/src/components/BaseLink/BaseLink.vue
+++ b/packages/vue/src/components/BaseLink/BaseLink.vue
@@ -165,10 +165,8 @@ export default defineComponent({
     computedTo() {
       let toValue = this.to ? this.addTrailingSlash(this.to as string) : undefined
       // filter out unnecessary `/home/` prefix from wagtail default site urlPaths
-      if (toValue && typeof toValue === 'string') {
-        if (toValue.startsWith('/home/')) {
-          toValue = toValue.replace('/home/', '/')
-        }
+      if (toValue && typeof toValue === 'string' && toValue.startsWith('/home/')) {
+        toValue = toValue.replace('/home/', '/')
       }
       return toValue
     },

--- a/packages/vue/src/components/BaseLink/BaseLink.vue
+++ b/packages/vue/src/components/BaseLink/BaseLink.vue
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { parse } from 'urllib'
 import { defineComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useThemeStore } from '../../store/theme'

--- a/packages/vue/src/components/BaseLink/BaseLink.vue
+++ b/packages/vue/src/components/BaseLink/BaseLink.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { parse } from 'urllib'
 import { defineComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useThemeStore } from '../../store/theme'
@@ -163,12 +164,18 @@ export default defineComponent({
       return undefined
     },
     computedTo() {
-      let toValue = this.to
+      let toValue = this.to ? this.addTrailingSlash(this.to as string) : undefined
       // filter out unnecessary `/home/` prefix from wagtail default site urlPaths
-      if (toValue && typeof toValue === 'string' && toValue.startsWith('/home/')) {
-        toValue = toValue.replace('/home/', '/')
+      if (toValue && typeof toValue === 'string') {
+        if (toValue.startsWith('/home/')) {
+          toValue = toValue.replace('/home/', '/')
+        }
       }
       return toValue
+    },
+    computedHref() {
+      let hrefValue = this.href ? this.addTrailingSlash(this.href as string) : undefined
+      return hrefValue
     }
   },
   methods: {
@@ -176,6 +183,28 @@ export default defineComponent({
       this.$root?.$emit('linkClicked')
       this.$emit('specificLinkClicked')
       eventBus.emit('linkClicked')
+    },
+    addTrailingSlash(path: string) {
+      let filteredPath = path
+      const isFilePath = () => {
+        const afterLashSlash = path.split('/').pop()
+        if (afterLashSlash && afterLashSlash.includes('.')) {
+          return true
+        }
+        return false
+      }
+      const isQueryPath = path.includes('?')
+      if (!isFilePath() && path !== '/' && !path.endsWith('/') && !path.startsWith('/preview')) {
+        // add a trailing slash if there isn't one
+        filteredPath += '/'
+      } else if (isQueryPath) {
+        // also add a trailing slash to paths with query params
+        const urlParts = filteredPath.split('?')
+        const queryParams = urlParts.shift()
+        const pathWithSlash = `${urlParts[0]}/`
+        filteredPath = pathWithSlash + queryParams
+      }
+      return filteredPath
     }
   }
 })
@@ -220,8 +249,8 @@ export default defineComponent({
       </template>
     </nuxt-link>
     <a
-      v-else-if="href"
-      :href="href"
+      v-else-if="computedHref"
+      :href="computedHref"
       class="group"
       :class="computedClass"
       :target="theTarget"


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Adds a trailing slash to all links regardless if it's a router link or not. Checks urls for files and query params.

## Instructions to test

Not testable in Storybook as we use a mock component for `NuxtLink`. Best way to test is in www. To do this locally:

1. in www, replaced the `@explorer-1` packages in `/apps/frontend/package.json` with the paths in `/README.md`
2. `pnpm i`
3. `make frontend-local`

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
