### PR TITLE
fix: path.includes is not a function

### DIFF
--- a/packages/vue/src/components/BaseLink/BaseLink.vue
+++ b/packages/vue/src/components/BaseLink/BaseLink.vue
@@ -186,40 +186,42 @@ export default defineComponent({
     },
     addTrailingSlash(path: string) {
       let filteredPath = path
-      const isFilePath = () => {
-        const afterLastSlash = path.split('/').pop()
-        if (afterLastSlash && afterLastSlash.includes('.')) {
-          return true
+      if (path && typeof path === 'string') {
+        const isFilePath = () => {
+          const afterLastSlash = path.split('/').pop()
+          if (afterLastSlash && afterLastSlash.includes('.')) {
+            return true
+          }
+          return false
         }
-        return false
-      }
-      const isQueryPath = path.includes('?')
-      const isAnchorPath = path.includes('#')
-      if (
-        !isQueryPath &&
-        !isAnchorPath &&
-        !isFilePath() &&
-        path !== '/' &&
-        !path.endsWith('/') &&
-        !path.startsWith('/preview')
-      ) {
-        // add a trailing slash if there isn't one
-        filteredPath += '/'
-      } else if (isQueryPath) {
-        if (!path.includes('/?')) {
-          // also add a trailing slash to paths with query params
-          const urlParts = filteredPath.split('?')
-          const pathWithSlash = `${urlParts[0]}/`
-          const queryParams = urlParts[1]
-          filteredPath = pathWithSlash + '?' + queryParams
-        }
-      } else if (isAnchorPath) {
-        if (!path.includes('/#')) {
-          // also add a trailing slash to paths with anchors
-          const urlParts = filteredPath.split('#')
-          const pathWithSlash = `${urlParts[0]}/`
-          const anchor = urlParts[1]
-          filteredPath = pathWithSlash + '#' + anchor
+        const isQueryPath = path.includes('?')
+        const isAnchorPath = path.includes('#')
+        if (
+          !isQueryPath &&
+          !isAnchorPath &&
+          !isFilePath() &&
+          path !== '/' &&
+          !path.endsWith('/') &&
+          !path.startsWith('/preview')
+        ) {
+          // add a trailing slash if there isn't one
+          filteredPath += '/'
+        } else if (isQueryPath) {
+          if (!path.includes('/?')) {
+            // also add a trailing slash to paths with query params
+            const urlParts = filteredPath.split('?')
+            const pathWithSlash = `${urlParts[0]}/`
+            const queryParams = urlParts[1]
+            filteredPath = pathWithSlash + '?' + queryParams
+          }
+        } else if (isAnchorPath) {
+          if (!path.includes('/#')) {
+            // also add a trailing slash to paths with anchors
+            const urlParts = filteredPath.split('#')
+            const pathWithSlash = `${urlParts[0]}/`
+            const anchor = urlParts[1]
+            filteredPath = pathWithSlash + '#' + anchor
+          }
         }
       }
       return filteredPath

--- a/packages/vue/src/components/PastEventsCarousel/PastEventsCarousel.vue
+++ b/packages/vue/src/components/PastEventsCarousel/PastEventsCarousel.vue
@@ -3,14 +3,7 @@
     v-if="hasContent"
     heading="Past Events"
     variant="cards"
-    :link="{
-      // path: 'events',
-      query: {
-        event_status: 'Past events',
-        sortBy: 'eventStartDateLatest',
-        page: '1'
-      }
-    }"
+    link="/events/?page=1&event_status=Past+events&sortBy=eventStartDateLatest"
     link-title="View all past events"
     indent="col-1"
     v-bind="$attrs"


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

- adding guard to `addTrailingSlash` in BaseLink
- changing link object to string in PastEventsCarousel

## Instructions to test

1. Test locally with www ([see instructions here](https://github.com/nasa-jpl/explorer-1/pull/661))
2. Make sure to have at least one www past event
3. View the events page
4. There should be no error
5. There should be a past events carousel at the bottom of the page with the link to view all past events
6. Click the link. it should work
7. Check test cases used in https://github.com/nasa-jpl/explorer-1/pull/662. They should still work as expected

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
