### PR TITLE
fix: Various NavMobile and NavJumpMenu fixes for EDU

### DIFF
--- a/packages/vue/src/components/NavMobile/NavMobile.vue
+++ b/packages/vue/src/components/NavMobile/NavMobile.vue
@@ -44,7 +44,6 @@
               <BaseLink
                 class="text-white font-bold text-xl pl-px"
                 to="/edubeta/"
-                link-class="py-2"
                 variant="none"
               >
                 Education</BaseLink

--- a/packages/vue/src/components/NavMobile/NavMobile.vue
+++ b/packages/vue/src/components/NavMobile/NavMobile.vue
@@ -41,7 +41,14 @@
               v-if="themeStore.theme === 'ThemeEdu'"
               class="-ml-1 pl-2 border-l border-white border-opacity-30 z-20 print:border-black"
             >
-              <span class="text-white font-bold text-xl pl-px">Education</span>
+              <BaseLink
+                class="text-white font-bold text-xl pl-px"
+                to="/edubeta/"
+                link-class="py-2"
+                variant="none"
+              >
+                Education</BaseLink
+              >
             </div>
           </div>
           <button

--- a/packages/vue/src/components/NavSecondary/NavSecondary.vue
+++ b/packages/vue/src/components/NavSecondary/NavSecondary.vue
@@ -189,6 +189,7 @@ export default defineComponent({
 .NavSecondary {
   top: -1px; // for intersection observer to work
   @apply sticky z-40 w-full bg-white border-b border-gray-mid border-opacity-0 transition-border-opacity duration-150 edu:duration-300 ease-in;
+  @apply hidden;
   @screen lg {
     @apply block;
   }

--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
@@ -123,55 +123,58 @@ const { heading, blocks, image, procedures, text } = reactive(props)
   // Assumes font-size for body element is a constant 16px
   @return math.div($pxValue, 16) * 1rem;
 }
-.PageEduProcedureSection {
-  .PageEduProcedureSectionSteps {
-    counter-reset: step;
-  }
-  .PageEduProcedureSectionSingleStep {
-    li:not(:last-of-type) .BlockStreamfield {
-      @apply -mb-5;
+.PageEduLessonSection {
+  @apply overflow-x-hidden;
+  .PageEduProcedureSection {
+    .PageEduProcedureSectionSteps {
+      counter-reset: step;
     }
-  }
-  ol.PageEduProcedureSectionSingleStep {
-    @apply list-none;
-    > li {
-      @apply relative w-full;
-      counter-increment: step;
-      &::before {
-        @apply relative block w-[45rem] mx-auto h-0 pl-1;
-        content: counter(step) '. ';
-        // mimicking .text-body-lg
-        font-size: pxToRem(18);
-        line-height: 1.6667;
+    .PageEduProcedureSectionSingleStep {
+      li:not(:last-of-type) .BlockStreamfield {
+        @apply -mb-5;
       }
+    }
+    ol.PageEduProcedureSectionSingleStep {
+      @apply list-none;
+      > li {
+        @apply relative w-full;
+        counter-increment: step;
+        &::before {
+          @apply relative block w-[45rem] mx-auto h-0 pl-1;
+          content: counter(step) '. ';
+          // mimicking .text-body-lg
+          font-size: pxToRem(18);
+          line-height: 1.6667;
+        }
 
-      @screen sm {
-        &::before {
-          @apply w-[47rem];
-          font-size: pxToRem(19);
+        @screen sm {
+          &::before {
+            @apply w-[47rem];
+            font-size: pxToRem(19);
+          }
         }
-      }
-      @screen md {
-        &::before {
-          @apply w-[51.5rem];
-          font-size: pxToRem(20);
+        @screen md {
+          &::before {
+            @apply w-[51.5rem];
+            font-size: pxToRem(20);
+          }
         }
-      }
-      @screen lg {
-        &::before {
-          @apply w-[46rem] pl-0;
-          font-size: pxToRem(21);
+        @screen lg {
+          &::before {
+            @apply w-[46rem] pl-0;
+            font-size: pxToRem(21);
+          }
         }
-      }
-      @screen xl {
-        &::before {
-          @apply w-[59rem];
-          font-size: pxToRem(22);
+        @screen xl {
+          &::before {
+            @apply w-[59rem];
+            font-size: pxToRem(22);
+          }
         }
-      }
-      @screen 2xl {
-        &::before {
-          // @apply w-[58.5rem];
+        @screen 2xl {
+          &::before {
+            // @apply w-[58.5rem];
+          }
         }
       }
     }

--- a/packages/vue/src/templates/edu/PageEduStudentProject/PageEduStudentProjectSection.vue
+++ b/packages/vue/src/templates/edu/PageEduStudentProject/PageEduStudentProjectSection.vue
@@ -172,52 +172,55 @@ const { heading, blocks, image, steps, stepsNumbering, text } = reactive(props)
   // Assumes font-size for body element is a constant 16px
   @return math.div($pxValue, 16) * 1rem;
 }
-.PageEduStudentProjectStep {
-  &:target {
-    @apply scroll-mt-14;
-  }
-  .BlockStreamfield {
-    div:last-child {
-      @apply mb-0 #{!important};
+.PageEduStudentProjectSection {
+  @apply overflow-x-hidden;
+  .PageEduStudentProjectStep {
+    &:target {
+      @apply scroll-mt-14;
     }
-  }
-  .caption-area {
-    @apply px-0;
-  }
-  .steps-numbering {
-    // intentionally overriding correction that occurs within ThemeVariantGray
-    @apply text-jpl-red;
-  }
-  .LayoutHelper > div > .BlockText {
-    .richtext-image {
-      &.right,
-      &.left {
-        @apply lg:max-w-md;
-      }
-      &.right {
-        @apply mr-0;
-      }
-      &.left {
-        @apply ml-0;
+    .BlockStreamfield {
+      div:last-child {
+        @apply mb-0 #{!important};
       }
     }
-  }
-
-  .PageEduStudentProjectStep__fullWidth {
+    .caption-area {
+      @apply px-0;
+    }
+    .steps-numbering {
+      // intentionally overriding correction that occurs within ThemeVariantGray
+      @apply text-jpl-red;
+    }
     .LayoutHelper > div > .BlockText {
-      p,
-      li {
-        @screen lg {
-          @apply pr-[9rem];
+      .richtext-image {
+        &.right,
+        &.left {
+          @apply lg:max-w-md;
         }
-        @screen xl {
-          @apply pr-[13rem];
+        &.right {
+          @apply mr-0;
+        }
+        &.left {
+          @apply ml-0;
         }
       }
-      table {
+    }
+
+    .PageEduStudentProjectStep__fullWidth {
+      .LayoutHelper > div > .BlockText {
         p,
         li {
-          @apply pr-0;
+          @screen lg {
+            @apply pr-[9rem];
+          }
+          @screen xl {
+            @apply pr-[13rem];
+          }
+        }
+        table {
+          p,
+          li {
+            @apply pr-0;
+          }
         }
       }
     }


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Fixes regressions (some introduced in https://github.com/nasa-jpl/explorer-1/pull/656/):
- https://github.com/nasa-jpl/www/issues/700
- https://github.com/nasa-jpl/www/issues/702
- https://github.com/nasa-jpl/www/issues/704

Changes:
- sets `overflow-x` to hidden on "Section" divs within the EDU Lesson template and EDU Student Project templates
- adds back `hidden` class to NavJumpMenu at smaller screen sizes
- wraps `Education` in `BaseLink` in `NavMobile`

## Instructions to test

<!-- Provide instructions on how a reviewer can verify your work. -->

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
