### PR TITLE
fix: using safari-supported method of defining list marker character

### DIFF
--- a/packages/common/src/scss/components/_BlockKeyPoints.scss
+++ b/packages/common/src/scss/components/_BlockKeyPoints.scss
@@ -2,10 +2,10 @@
   @media not print {
     ul {
       @apply ml-6;
+      list-style-type: '—';
     }
     ul li {
       &::marker {
-        content: '—';
         @apply leading-none text-primary font-medium text-[22px] lg:text-[24px];
       }
       @apply pl-2 lg:pl-4;

--- a/packages/common/src/scss/components/_BlockText.scss
+++ b/packages/common/src/scss/components/_BlockText.scss
@@ -95,10 +95,10 @@
     }
   }
   ul {
+    list-style-type: '—';
     li {
       @apply pl-2 lg:pl-4;
       &::marker {
-        content: '—';
         @apply leading-none text-primary font-medium text-[22px] lg:text-[28px];
       }
     }


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses:
- https://github.com/nasa-jpl/www/issues/699

Changes:
- Removes `content` from `::marker` rules and uses `list-style-type: '—'` instead

## Instructions to test

1. `make vue-storybook`
2. In Chrome, Firefox and Safari, view these stories:
- http://localhost:6006/?path=/story/components-blocks-blocktext--base-story&globals=theme:ThemeEdu
- http://localhost:6006/?path=/story/components-blocks-blocktext--rich-text-media&globals=theme:ThemeEdu
3. Make sure the custom bullets are visible in all browsers

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [x] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [x] Safari
- [ ] Edge
