### PR TITLE
applying indent to containing div of Lesson > Procedure > Step instead of list item

### DIFF
--- a/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
+++ b/packages/vue/src/templates/edu/PageEduLesson/PageEduLessonSection.vue
@@ -135,8 +135,11 @@ const { heading, blocks, image, procedures, text } = reactive(props)
       }
     }
     ol.PageEduProcedureSectionSingleStep {
-      @apply list-none indent-7 pr-4 xl:indent-0.5 xl:pr-0.5;
+      @apply list-none pl-7;
       text-wrap: pretty;
+      @screen lg {
+        @apply pl-0;
+      }
       > li {
         @apply relative w-full;
         counter-increment: step;


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses
- https://github.com/nasa-jpl/www/issues/708

## Instructions to test

1. `make vue-storybook`
2. view a lesson story with a mobile viewport: http://localhost:6006/iframe.html?globals=theme:ThemeEdu&args=&id=templates-edu-pageedulesson--base-story#/

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
