### PR TITLE
fix: passing link prop to mobile block link grid cards

### DIFF
--- a/packages/vue/src/components/BlockCardGrid/BlockCardGrid.vue
+++ b/packages/vue/src/components/BlockCardGrid/BlockCardGrid.vue
@@ -28,6 +28,7 @@
         :title="card.title"
         :text="card.description"
         :image="card.image"
+        :link="card.link"
         class="swiper-slide mb-5"
       />
     </MixinCarousel>

--- a/packages/vue/src/components/BlockCardGrid/BlockCardGrid.vue
+++ b/packages/vue/src/components/BlockCardGrid/BlockCardGrid.vue
@@ -7,7 +7,7 @@
       <BlockCardGridItem
         v-for="(card, index) of cards"
         :key="`item-${index}`"
-        class="col-span-1"
+        wrapper-class="col-span-1"
         :label="card.label"
         :title="card.title"
         :description="card.description"
@@ -23,13 +23,13 @@
     >
       <BlockCardGridItem
         v-for="(card, index) of cards"
-        :key="index"
+        :key="`item-mobile-${index}`"
         :label="card.label"
         :title="card.title"
         :text="card.description"
         :image="card.image"
         :link="card.link"
-        class="swiper-slide mb-5"
+        wrapper-class="swiper-slide mb-5"
       />
     </MixinCarousel>
   </div>

--- a/packages/vue/src/components/BlockCardGridItem/BlockCardGridItem.vue
+++ b/packages/vue/src/components/BlockCardGridItem/BlockCardGridItem.vue
@@ -5,6 +5,7 @@
     :to="link?.page?.url ? link.page.url : undefined"
     :href="link?.externalLink ? link?.externalLink : undefined"
     class="BlockCardGridItem group"
+    :class="wrapperClass"
     external-target-blank
   >
     <BlockCardGridItemElement
@@ -14,6 +15,7 @@
   </BaseLink>
   <BlockCardGridItemElement
     v-else
+    :class="wrapperClass"
     v-bind="$attrs"
   />
 </template>
@@ -32,6 +34,11 @@ export default defineComponent({
   props: {
     link: {
       type: Object as PropType<LinkObject>,
+      required: false,
+      default: undefined
+    },
+    wrapperClass: {
+      type: String,
       required: false,
       default: undefined
     }


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses:
- https://github.com/nasa-jpl/www/issues/746

Changes:
- adds `link` prop to mobile template for BlockCardGrid
- adds specific wrapper-class prop

## Instructions to test

1. `make vue-storybook`
2. View http://localhost:6006/iframe.html?globals=&args=&id=components-blocks-blockcardgrid--base-story#/
3. Check that the second card is a link (not all cards are links in the story). Check for the same link in mobile view.

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
