### PR TITLE
fixing link logic in HomepageTeaserBlock

### DIFF
--- a/.changeset/slimy-hairs-rush.md
+++ b/.changeset/slimy-hairs-rush.md
@@ -1,0 +1,5 @@
+---
+"@explorer-1/vue": patch
+---
+
+Fixing link logic in HomepageTeaserBlock

--- a/packages/vue/src/components/HomepageTeaserBlock/HomepageTeaserBlock.vue
+++ b/packages/vue/src/components/HomepageTeaserBlock/HomepageTeaserBlock.vue
@@ -33,14 +33,14 @@
             class="lg:pr-14"
             :text="data.paragraph"
           />
-          <template v-if="data.link && theLink">
+          <template v-if="data.link || theExternalLink">
             <BaseLink
               variant="primary"
               class="mt-5"
               link-class="inline-block"
               caret-wrapper-class="py-2"
-              :href="theLink"
-              :to="data.link.page ? data.link.page.url : null"
+              :href="theExternalLink"
+              :to="data.link.page ? data.link.page.url : undefined"
               external-target-blank
             >
               {{ data.link.text }}
@@ -60,13 +60,13 @@
               v-if="theCard.image"
               class="relative h-auto"
             >
-              <template v-if="theCard.link && theLink">
+              <template v-if="theCardExternalLink || theCard.link">
                 <BaseLink
                   variant="none"
                   link-class="block"
                   :aria-label="theCard.link.text || 'Learn more'"
-                  :href="theLink"
-                  :to="theCard.link.page ? theCard.link.page.url : null"
+                  :href="theCardExternalLink"
+                  :to="theCard.link.page?.url || undefined"
                   external-target-blank
                 >
                   <HomepageTeaserBlockCardImage :data="theCard" />
@@ -87,14 +87,14 @@
                 {{ theCard.description }}
               </p>
 
-              <template v-if="theCard.link && theLink">
+              <template v-if="theCard.link && theCardExternalLink">
                 <BaseLink
                   variant="primary"
                   class="mt-3"
                   link-class="inline-block"
                   caret-wrapper-class="py-2"
-                  :href="theLink"
-                  :to="theCard.link.page ? theCard.link.page.url : null"
+                  :href="theCardExternalLink"
+                  :to="theCard.link.page ? theCard.link.page.url : undefined"
                   external-target-blank
                 >
                   {{ theCard.link.text }}
@@ -135,11 +135,11 @@ export default defineComponent({
     }
   },
   computed: {
-    theCard(): object | null {
-      if (this.data.card && this.data.card.length > 0) {
-        return this.data.card[0]
+    theCard(): object | undefined {
+      if (this.data?.card && this.data.card.length > 0) {
+        return this.data?.card[0]
       }
-      return null
+      return undefined
     },
     hasCoverImage(): boolean {
       if (this.data.coverImage && this.data.coverImage.src) {
@@ -147,8 +147,11 @@ export default defineComponent({
       }
       return false
     },
-    theLink() {
-      return mixinGetExternalLink(this.data.link) || undefined
+    theExternalLink() {
+      return mixinGetExternalLink(this.data?.link) || undefined
+    },
+    theCardExternalLink() {
+      return mixinGetExternalLink(this.theCard?.link) || undefined
     },
     theSrcSet() {
       return this.data.coverImage

--- a/packages/vue/src/components/HomepageTeaserBlock/HomepageTeaserBlock.vue
+++ b/packages/vue/src/components/HomepageTeaserBlock/HomepageTeaserBlock.vue
@@ -60,7 +60,7 @@
               v-if="theCard.image"
               class="relative h-auto"
             >
-              <template v-if="theCardExternalLink || theCard.link">
+              <template v-if="theCard.link || theCardExternalLink">
                 <BaseLink
                   variant="none"
                   link-class="block"
@@ -87,7 +87,7 @@
                 {{ theCard.description }}
               </p>
 
-              <template v-if="theCard.link && theCardExternalLink">
+              <template v-if="theCard.link || theCardExternalLink">
                 <BaseLink
                   variant="primary"
                   class="mt-3"

--- a/packages/vue/src/utils/mixins.ts
+++ b/packages/vue/src/utils/mixins.ts
@@ -217,9 +217,9 @@ export const mixinGetSrcSet = (srcSetObject: Partial<ImageObject>): string => {
 }
 // Use with RelatedLinkBlock to retrieve the external link to use with an href prop
 export const mixinGetExternalLink = (link: RelatedLinkObject): string | undefined => {
-  if (link.externalLink) {
+  if (link?.externalLink) {
     return link.externalLink
-  } else if (link.document) {
+  } else if (link?.document) {
     return link.document.url
   }
   return undefined


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Fixes link logic in HomepageTeaserBlock by separating link logic between the card and main block. Fixes the link to the virtual tour on the homepage.

## Instructions to test

1. `make vue-storybook`
2. View the component story. Both links should render: http://localhost:6006/?path=/docs/components-www-homepage-homepageteaserblock--docs

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
