### PR TITLE
fix: allowing hero videos to be inline on news pages

### DIFF
--- a/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.stories.js
+++ b/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.stories.js
@@ -41,7 +41,7 @@ export const BaseStory = {
           url: 'http://localhost:3000/topics/mars'
         }
       ],
-      showShareLinks: true,
+      hideShareLinks: false,
       topper: '',
       readTime: '2 min read',
       summary:
@@ -116,7 +116,8 @@ export const HeroVideo = {
           blockType: 'VideoBlock',
           video: BaseVideoData,
           caption: 'Lorem ipsum dolor sit amet',
-          credit: 'NASA/JPL'
+          credit: 'NASA/JPL',
+          autoplay: true
         }
       ]
     }

--- a/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.stories.js
+++ b/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.stories.js
@@ -41,7 +41,7 @@ export const BaseStory = {
           url: 'http://localhost:3000/topics/mars'
         }
       ],
-      hideShareLinks: false,
+      showShareLinks: true,
       topper: '',
       readTime: '2 min read',
       summary:
@@ -116,8 +116,7 @@ export const HeroVideo = {
           blockType: 'VideoBlock',
           video: BaseVideoData,
           caption: 'Lorem ipsum dolor sit amet',
-          credit: 'NASA/JPL',
-          autoplay: true
+          credit: 'NASA/JPL'
         }
       ]
     }

--- a/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.stories.js
+++ b/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.stories.js
@@ -116,7 +116,8 @@ export const HeroVideo = {
           blockType: 'VideoBlock',
           video: BaseVideoData,
           caption: 'Lorem ipsum dolor sit amet',
-          credit: 'NASA/JPL'
+          credit: 'NASA/JPL',
+          autoplay: true
         }
       ]
     }

--- a/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.vue
+++ b/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.vue
@@ -83,7 +83,7 @@
 
     <!-- share buttons -->
     <LayoutHelper
-      v-if="data.showShareLinks"
+      v-if="!data.hideShareLinks"
       indent="col-2"
       class="lg:mb-0 relative mb-8"
     >

--- a/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.vue
+++ b/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.vue
@@ -207,16 +207,13 @@ export default defineComponent({
       return (this.data?.hero || []).length === 0
     },
     heroInline(): boolean {
-      if (!this.heroEmpty) {
-        if (this.data?.hero[0].blockType === 'VideoBlock') {
-          return false
-        } else if (
-          this.data?.heroPosition === 'inline' ||
+      if (
+        !this.heroEmpty &&
+        (this.data?.heroPosition === 'inline' ||
           this.data?.hero[0].blockType === 'CarouselBlock' ||
-          this.data?.hero[0].blockType === 'VideoEmbedBlock'
-        ) {
-          return true
-        }
+          this.data?.hero[0].blockType === 'VideoEmbedBlock')
+      ) {
+        return true
       }
       return false
     },

--- a/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.vue
+++ b/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.vue
@@ -83,7 +83,7 @@
 
     <!-- share buttons -->
     <LayoutHelper
-      v-if="!data.hideShareLinks"
+      v-if="data.showShareLinks"
       indent="col-2"
       class="lg:mb-0 relative mb-8"
     >

--- a/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.vue
+++ b/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.vue
@@ -176,7 +176,7 @@ import BlockImageStandard from './../../components/BlockImage/BlockImageStandard
 import BlockLinkCarousel from './../../components/BlockLinkCarousel/BlockLinkCarousel.vue'
 import ShareButtons from './../../components/ShareButtons/ShareButtons.vue'
 import BlockText from './../../components/BlockText/BlockText.vue'
-import BlockVideo from './../../components/BlockText/BlockText.vue'
+import BlockVideo from './../../components/BlockVideo/BlockVideo.vue'
 
 export default defineComponent({
   name: 'PageNewsDetail',


### PR DESCRIPTION
### Checklist

- [ ] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Fixes a regression that occurred during the EDU update. On WWW news stories, hero videos can be full width or inline. Currently, they are being forced to full-width:
- Live link (full bleed): https://www.jpl.nasa.gov/news/testing-proves-its-worth-with-successful-mars-parachute-deployment/
- Wayback machine link (inline): https://web.archive.org/web/20230815021436/https://www.jpl.nasa.gov/news/testing-proves-its-worth-with-successful-mars-parachute-deployment/

## Instructions to test

1. `make vue-storybook`
2. View the news story: http://localhost:6006/?path=/story/templates-pagenewsdetail--hero-video
3. View the news story with video inlined: http://localhost:6006/?path=/story/templates-pagenewsdetail--hero-video&args=data.heroPosition:inline

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
