### PR TITLE
Fix: restoring dynamic height in HeroMedia

### DIFF
--- a/packages/common/src/scss/components/_HeroMedia.scss
+++ b/packages/common/src/scss/components/_HeroMedia.scss
@@ -1,7 +1,7 @@
 .HeroMedia {
   > div > .vh-crop {
     @screen sm {
-      max-height: 65vh;
+      max-height: 40vh;
       min-height: 255px;
     }
 
@@ -10,11 +10,11 @@
     }
 
     @screen lg {
-      min-height: 375px;
+      min-height: 345px;
     }
 
     @screen xl {
-      min-height: 430px;
+      min-height: 400px;
     }
 
     > .hero {

--- a/packages/vue/src/components/HeroMedia/HeroMedia.vue
+++ b/packages/vue/src/components/HeroMedia/HeroMedia.vue
@@ -3,40 +3,42 @@
     v-if="image || video"
     class="HeroMedia"
   >
-    <div class="vh-crop max-w-screen-3xl relative flex items-center mx-auto overflow-hidden">
-      <div class="hero w-full">
-        <template v-if="theImageData">
-          <img
-            v-if="theImageData.src"
-            class="object-cover object-center w-full h-full"
-            :srcset="theSrcSet"
-            :src="theImageData.src.url"
-            :width="theImageData.src.width"
-            :height="theImageData.src.height"
-            :alt="theImageData.alt"
-            itemprop="image"
-            data-chromatic="ignore"
-          />
-        </template>
-        <template v-else-if="video">
-          <MixinVideoBg :video="video" />
-        </template>
-      </div>
-      <div
-        v-if="hasCaptionArea"
-        class="lg:hidden absolute bottom-0 left-0 w-full h-auto mx-auto print:hidden"
-      >
-        <button
-          class="bg-opacity-90 text-gray-dark flex items-center justify-center w-12 h-12 ml-auto bg-white cursor-pointer"
-          aria-label="Toggle caption"
-          @click="toggleCaption"
+    <div>
+      <div class="vh-crop max-w-screen-3xl relative flex items-center mx-auto overflow-hidden">
+        <div class="hero w-full">
+          <template v-if="theImageData">
+            <img
+              v-if="theImageData.src"
+              class="object-cover object-center w-full h-full"
+              :srcset="theSrcSet"
+              :src="theImageData.src.url"
+              :width="theImageData.src.width"
+              :height="theImageData.src.height"
+              :alt="theImageData.alt"
+              itemprop="image"
+              data-chromatic="ignore"
+            />
+          </template>
+          <template v-else-if="video">
+            <MixinVideoBg :video="video" />
+          </template>
+        </div>
+        <div
+          v-if="hasCaptionArea"
+          class="lg:hidden absolute bottom-0 left-0 w-full h-auto mx-auto print:hidden"
         >
-          <IconInfo
-            v-show="!captionVisible"
-            class="text-xl"
-          />
-          <IconClose v-show="captionVisible" />
-        </button>
+          <button
+            class="bg-opacity-90 text-gray-dark flex items-center justify-center w-12 h-12 ml-auto bg-white cursor-pointer"
+            aria-label="Toggle caption"
+            @click="toggleCaption"
+          >
+            <IconInfo
+              v-show="!captionVisible"
+              class="text-xl"
+            />
+            <IconClose v-show="captionVisible" />
+          </button>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Fixes a regression. `HeroMedia` will  now adjust height based on the viewport. This broke because a `div` was removed. The `div` has now been restored. Some heights have been adjusted to accommodate recent feedback about too-large hero images.

## Instructions to test

1. `make vue-storybook`
2. View http://localhost:6006/iframe.html?globals=&args=&id=components-heroes-media-only--base-story#/ and try different viewport sizes. You should see the height change if your viewport is shorter.

## Tested in the following environments/browsers:


### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
