### PR TITLE
Fix: Caption in Hero video embeds

### DIFF
--- a/packages/vue/src/components/HeroInlineMedia/HeroInlineMedia.vue
+++ b/packages/vue/src/components/HeroInlineMedia/HeroInlineMedia.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { reactive } from 'vue'
-import BaseImagePlaceholder from './../BaseImagePlaceholder/BaseImagePlaceholder.vue'
+import BlockVideoEmbed from './../BlockVideoEmbed/BlockVideoEmbed.vue'
 import BlockIframeEmbed from './../BlockIframeEmbed/BlockIframeEmbed.vue'
 import BlockImageComparison from './../BlockImageComparison/BlockImageComparison.vue'
 import BlockImageCarousel from './../BlockImageCarousel/BlockImageCarousel.vue'
@@ -42,13 +42,10 @@ const { heroBlocks, constrain } = reactive(props)
       v-else-if="heroBlocks[0].blockType === 'VideoBlock'"
       :data="heroBlocks[0]"
     />
-    <BaseImagePlaceholder
+    <BlockVideoEmbed
       v-else-if="heroBlocks[0].blockType === 'VideoEmbedBlock'"
-      aspect-ratio="16:9"
-      dark-mode
-    >
-      <div v-html="heroBlocks[0].embed?.embed"></div>
-    </BaseImagePlaceholder>
+      :data="heroBlocks[0]"
+    />
     <BlockImageComparison
       v-else-if="heroBlocks[0].blockType === 'ImageComparisonBlock'"
       :data="heroBlocks[0]"

--- a/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.vue
+++ b/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.vue
@@ -145,14 +145,10 @@ import DetailHeadline from './../../components/DetailHeadline/DetailHeadline.vue
 import BlockStreamfield from './../../components/BlockStreamfield/BlockStreamfield.vue'
 import NewsDetailMediaContact from './../../components/NewsDetailMediaContact/NewsDetailMediaContact.vue'
 import BlockRelatedLinks from './../../components/BlockRelatedLinks/BlockRelatedLinks.vue'
-import BlockImageCarousel from './../../components/BlockImageCarousel/BlockImageCarousel.vue'
-import BlockImageComparison from './../../components/BlockImageComparison/BlockImageComparison.vue'
-import BlockImageStandard from './../../components/BlockImage/BlockImageStandard.vue'
 import HeroInlineMedia from './../../components/HeroInlineMedia/HeroInlineMedia.vue'
 import BlockLinkCarousel from './../../components/BlockLinkCarousel/BlockLinkCarousel.vue'
 import ShareButtons from './../../components/ShareButtons/ShareButtons.vue'
 import BlockText from './../../components/BlockText/BlockText.vue'
-import BlockVideo from './../../components/BlockVideo/BlockVideo.vue'
 
 export default defineComponent({
   name: 'PageNewsDetail',
@@ -163,13 +159,9 @@ export default defineComponent({
     BlockStreamfield,
     NewsDetailMediaContact,
     BlockRelatedLinks,
-    BlockImageCarousel,
-    BlockImageComparison,
-    BlockImageStandard,
     BlockLinkCarousel,
     ShareButtons,
     BlockText,
-    BlockVideo,
     HeroInlineMedia
   },
   props: {

--- a/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.vue
+++ b/packages/vue/src/templates/PageNewsDetail/PageNewsDetail.vue
@@ -51,33 +51,9 @@
       indent="col-2"
       class="lg:mb-22 mt-10 mb-10"
     >
-      <BlockImageStandard
-        v-if="data.hero[0].blockType === 'HeroImageBlock'"
-        :data="data.hero[0].imageInline"
-        :display-caption="data.hero[0].displayCaption"
-        :caption="data.hero[0].caption"
+      <HeroInlineMedia
+        :hero-blocks="data.hero"
         :constrain="data.heroConstrain"
-      />
-      <BlockImageCarousel
-        v-else-if="data.hero[0].blockType === 'CarouselBlock'"
-        :items="data.hero[0].blocks"
-        :block-id="data.hero[0].id"
-      />
-      <BlockVideo
-        v-else-if="data.hero[0].blockType === 'VideoBlock'"
-        :data="data.hero[0]"
-        autoplay
-      />
-      <BaseImagePlaceholder
-        v-else-if="data.hero[0].blockType === 'VideoEmbedBlock'"
-        aspect-ratio="16:9"
-        dark-mode
-      >
-        <div v-html="data.hero[0].embed.embed"></div>
-      </BaseImagePlaceholder>
-      <BlockImageComparison
-        v-else-if="data.hero[0].blockType === 'ImageComparisonBlock'"
-        :data="data.hero[0]"
       />
     </LayoutHelper>
 
@@ -166,13 +142,13 @@ import { defineComponent } from 'vue'
 import LayoutHelper from './../../components/LayoutHelper/LayoutHelper.vue'
 import HeroMedia from './../../components/HeroMedia/HeroMedia.vue'
 import DetailHeadline from './../../components/DetailHeadline/DetailHeadline.vue'
-import BaseImagePlaceholder from './../../components/BaseImagePlaceholder/BaseImagePlaceholder.vue'
 import BlockStreamfield from './../../components/BlockStreamfield/BlockStreamfield.vue'
 import NewsDetailMediaContact from './../../components/NewsDetailMediaContact/NewsDetailMediaContact.vue'
 import BlockRelatedLinks from './../../components/BlockRelatedLinks/BlockRelatedLinks.vue'
 import BlockImageCarousel from './../../components/BlockImageCarousel/BlockImageCarousel.vue'
 import BlockImageComparison from './../../components/BlockImageComparison/BlockImageComparison.vue'
 import BlockImageStandard from './../../components/BlockImage/BlockImageStandard.vue'
+import HeroInlineMedia from './../../components/HeroInlineMedia/HeroInlineMedia.vue'
 import BlockLinkCarousel from './../../components/BlockLinkCarousel/BlockLinkCarousel.vue'
 import ShareButtons from './../../components/ShareButtons/ShareButtons.vue'
 import BlockText from './../../components/BlockText/BlockText.vue'
@@ -184,7 +160,6 @@ export default defineComponent({
     LayoutHelper,
     HeroMedia,
     DetailHeadline,
-    BaseImagePlaceholder,
     BlockStreamfield,
     NewsDetailMediaContact,
     BlockRelatedLinks,
@@ -194,7 +169,8 @@ export default defineComponent({
     BlockLinkCarousel,
     ShareButtons,
     BlockText,
-    BlockVideo
+    BlockVideo,
+    HeroInlineMedia
   },
   props: {
     data: {


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Fixes https://github.com/nasa-jpl/www-frontend/issues/1728

Updates `BlockHeroInline` to use `BlockVideoEmbed` instead of `BaseImagePlaceholder` for embedded videos (not sure why it was ever the latter).

Updates `PageNewsTemplate` to use `BlockHeroInline`

## Instructions to test

1. `make vue-storybook`
2. View the story: http://localhost:6006/?path=/story/templates-pagenewsdetail--hero-video-embed

You can also view the fix in [Percy's visual diff](https://percy.io/e5a03e0a/web/explorer-1/builds/39040471/changed/2108708789?browser=chrome&browser_ids=64&group_snapshots_by=similar_diff&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=1280&widths=375%2C1280). 

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
