### PR TITLE
Feature: Newsletter Signup block using form action

### DIFF
--- a/packages/vue/src/components/BaseRadioGroup/BaseRadioGroup.vue
+++ b/packages/vue/src/components/BaseRadioGroup/BaseRadioGroup.vue
@@ -43,7 +43,7 @@
           >
             <span
               v-if="option.title"
-              class="font-semibold"
+              :class="option.text ? 'font-semibold' : ''"
               >{{ option.title }}</span
             >
             <span v-if="option.text"> - </span>

--- a/packages/vue/src/components/BlockNewsletterSignup/BlockNewsletterSignup.stories.js
+++ b/packages/vue/src/components/BlockNewsletterSignup/BlockNewsletterSignup.stories.js
@@ -1,0 +1,21 @@
+import BlockNewsletterSignup from './BlockNewsletterSignup.vue'
+
+export default {
+  title: 'Components/Blocks/BlockNewsletterSignup',
+  component: BlockNewsletterSignup,
+  excludeStories: /.*Data$/
+}
+
+export const BlockNewsletterSignupData = {
+  blockType: 'NewsletterSignupBlock',
+  title: 'Get the JPL Newsletter',
+  description:
+    'From Mars to the Milky Way—never miss a discovery! Delivered straight to your inbox.',
+  buttonText: 'Sign Up'
+}
+
+export const BaseStory = {
+  args: {
+    data: BlockNewsletterSignupData
+  }
+}

--- a/packages/vue/src/components/BlockNewsletterSignup/BlockNewsletterSignup.vue
+++ b/packages/vue/src/components/BlockNewsletterSignup/BlockNewsletterSignup.vue
@@ -49,7 +49,6 @@
               class="text-nowrap"
               variant="primary"
               compact
-              @click="submit"
             >
               {{ data.buttonText }}
             </BaseButton>

--- a/packages/vue/src/components/BlockNewsletterSignup/BlockNewsletterSignup.vue
+++ b/packages/vue/src/components/BlockNewsletterSignup/BlockNewsletterSignup.vue
@@ -1,0 +1,178 @@
+<template>
+  <div
+    class="BlockNewsletterSignup bg-gray-light edu:bg-stars edu:bg-primary md:mx-0 sm:py-8 md:px-10 sm:mx-20 px-6 py-6 edu:text-white"
+  >
+    <div class="md:mx-16 xl:mx-24 text-center">
+      <p class="text-h6 edu:text-white edu:font-extrabold mb-3">{{ data.title }}</p>
+      <p>{{ data.description }}</p>
+    </div>
+    <hr class="text-gray-mid mt-6 mb-5" />
+
+    <div class="mb-3">
+      <form
+        id="ic_signupform"
+        target="_blank"
+        :captcha-key="captchaKey"
+        captcha-theme="light"
+        new-captcha="true"
+        method="POST"
+        :action="iContactForm"
+      >
+        <div
+          dataname="listGroups"
+          data-label="Which email groups would you like to join?"
+        >
+          <div>
+            <BaseRadioGroup
+              v-model="form.listgroups"
+              heading="Frequency:"
+              group="email"
+              title="Email Groups"
+              preselected="breaking"
+              :options="emailGroups"
+            />
+          </div>
+        </div>
+        <div class="flex flex-row flex-nowrap">
+          <TextInput
+            v-model="form.email"
+            class="email-container h-auto w-full"
+            input-name="data[email]"
+            label="Email"
+            type="email"
+            required
+            placeholder="Email address"
+            :show-label="false"
+          />
+          <div class="submit-container h-auto">
+            <BaseButton
+              class="text-nowrap"
+              variant="primary"
+              compact
+              @click="submit"
+            >
+              {{ data.buttonText }}
+            </BaseButton>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+// @ts-nocheck
+import { defineComponent } from 'vue'
+import { mapStores } from 'pinia'
+import { useThemeStore } from '../../store/theme'
+import BaseButton from './../BaseButton/BaseButton.vue'
+import BaseRadioGroup from './../BaseRadioGroup/BaseRadioGroup.vue'
+import TextInput from './../TextInput/TextInput.vue'
+
+const iContactForm =
+  'https://app.icontact.com/icp/core/mycontacts/signup/designer/form/?id=5&cid=1389932&lid=11365'
+
+const captchaKey = '6LeCZCcUAAAAALhxcQ5fN80W6Wa2K3GqRQK6WRjA'
+
+const iContactTrackingGif =
+  'https://app.icontact.com/icp/core/signup/tracking.gif?id=5&cid=1389932&lid=11365'
+
+const emailGroups = [
+  {
+    id: 'breaking',
+    title: 'Latest News',
+    value: '41031',
+    alt: 'Lists',
+    name: 'data[listGroups][]'
+  },
+  {
+    id: 'daily',
+    title: 'Daily',
+    value: '41032',
+    alt: 'Lists',
+    name: 'data[listGroups][]'
+  },
+  {
+    id: 'weekly',
+    title: 'Weekly',
+    value: '41033',
+    alt: 'Lists',
+    name: 'data[listGroups][]'
+  },
+  {
+    id: 'monthly',
+    title: 'Monthly',
+    value: '41034',
+    alt: 'Lists',
+    name: 'data[listGroups][]'
+  }
+]
+
+export default defineComponent({
+  name: 'BlockNewsletterSignup',
+  components: {
+    BaseButton,
+    BaseRadioGroup,
+    TextInput
+  },
+  props: {
+    data: {
+      type: Object,
+      required: true,
+      default: () => ({})
+    }
+  },
+  data() {
+    return {
+      submitted: false,
+      form: {
+        email: undefined,
+        listGroups: undefined
+      }
+    }
+  },
+  computed: {
+    ...mapStores(useThemeStore),
+    buttonVariant() {
+      return this.themeStore.theme === 'ThemeEdu' ? 'dark' : 'primary'
+    },
+    iContactForm() {
+      return iContactForm
+    },
+    iContactTrackingGif() {
+      return iContactTrackingGif
+    },
+    captchaKey() {
+      return captchaKey
+    },
+    emailGroups() {
+      return emailGroups
+    }
+  },
+  mounted() {
+    const validationScript = document.createElement('script')
+    validationScript.setAttribute(
+      'src',
+      'https://app.icontact.com/icp/static/form/javascripts/validation-captcha.js'
+    )
+    const trackingScript = document.createElement('script')
+    trackingScript.setAttribute(
+      'src',
+      'https://app.icontact.com/icp/static/form/javascripts/tracking.js'
+    )
+    document.head.appendChild(validationScript, trackingScript)
+  }
+})
+</script>
+<style type="scss">
+.BlockNewsletterSignup {
+  fieldset > div {
+    column-count: 2;
+  }
+  .email-container input {
+    @apply mt-0 -mr-1;
+  }
+  .BaseRadioGroup label {
+    @apply text-base text-left;
+  }
+}
+</style>

--- a/packages/vue/src/components/BlockStreamfield/BlockStreamfield.stories.js
+++ b/packages/vue/src/components/BlockStreamfield/BlockStreamfield.stories.js
@@ -16,6 +16,7 @@ import { BlockTeaserData } from './../BlockTeaser/BlockTeaser.stories'
 import { BlockIframeEmbedData } from './../BlockIframeEmbed/BlockIframeEmbed.stories'
 import { BlockVideoData } from './../BlockVideo/BlockVideo.stories'
 import { BlockVideoEmbedData } from './../BlockVideoEmbed/BlockVideoEmbed.stories'
+import { BlockNewsletterSignupData } from '../BlockNewsletterSignup/BlockNewsletterSignup.stories'
 import { MixedColumnWidths } from './../BlockRichTable/BlockRichTable.stories'
 import BlockStreamfield, { variants } from './BlockStreamfield.vue'
 
@@ -167,6 +168,7 @@ export const BlockStreamfieldData = {
         ]
       }
     },
+    BlockNewsletterSignupData,
     {
       blockType: 'ListBlock',
       field: 'card_grid',

--- a/packages/vue/src/components/BlockStreamfield/BlockStreamfield.vue
+++ b/packages/vue/src/components/BlockStreamfield/BlockStreamfield.vue
@@ -75,6 +75,14 @@
       >
         <BlockCta :data="block" />
       </LayoutHelper>
+      <LayoutHelper
+        v-else-if="block.blockType == 'NewsletterSignupBlock'"
+        :key="`newsletterSignupBlock${index}`"
+        indent="col-4"
+        :class="marginBottom"
+      >
+        <BlockNewsletterSignup :data="block" />
+      </LayoutHelper>
 
       <LayoutHelper
         v-else-if="block.blockType == 'TeaserBlock'"
@@ -277,6 +285,7 @@ import BlockVideo from './../BlockVideo/BlockVideo.vue'
 import BlockVideoEmbed, {
   type BlockData as VideoBlockEmbedData
 } from './../BlockVideoEmbed/BlockVideoEmbed.vue'
+import BlockNewsletterSignup from '../BlockNewsletterSignup/BlockNewsletterSignup.vue'
 import { mapStores } from 'pinia'
 import { useThemeStore } from '../../store/theme'
 
@@ -315,7 +324,8 @@ export default defineComponent({
     BlockIframeEmbed,
     BlockGist,
     BlockVideo,
-    BlockVideoEmbed
+    BlockVideoEmbed,
+    BlockNewsletterSignup
   },
   props: {
     variant: {

--- a/packages/vue/src/templates/PageContent/PageContent.vue
+++ b/packages/vue/src/templates/PageContent/PageContent.vue
@@ -16,6 +16,7 @@ import BlockRelatedLinks from './../../components/BlockRelatedLinks/BlockRelated
 import FormContact from './../../components/FormContact/FormContact.vue'
 import FormNewsletterSignup from './../../components/FormNewsletterSignup/FormNewsletterSignup.vue'
 import BlockLinkCarousel from './../../components/BlockLinkCarousel/BlockLinkCarousel.vue'
+import type { BlockData } from '../../interfaces'
 
 const route = useRoute()
 
@@ -71,6 +72,18 @@ export default defineComponent({
         return 'lg:mt-12 mt-5'
       }
       return 'lg:mt-12 lg:mb-18 edu:lg:mb-12 mt-5 mb-10 edu:mb-8'
+    },
+    hasNewsletterSignupBlock() {
+      let status = false
+      const blocks = this.data?.body
+      if (blocks?.length) {
+        blocks.forEach((block: BlockData) => {
+          if (block.blockType === `NewsletterSignupBlock`) {
+            status = true
+          }
+        })
+      }
+      return status
     }
   }
 })
@@ -168,7 +181,7 @@ export default defineComponent({
     </template>
 
     <!-- Newsletter Signup form for specific content page only -->
-    <template v-if="data.slug === 'newsletter-signup'">
+    <template v-if="data.slug === 'newsletter-signup' && !hasNewsletterSignupBlock">
       <!-- Newsletter Signup Form -->
       <FormNewsletterSignup class="lg:mb-18 mb-10" />
     </template>


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Adds a newsletter signup block (https://github.com/nasa-jpl/www-frontend/issues/1684) to Explorer 1. 

### Important Notes
- This signup block is specific to the JPL Newsletter
- Valid Captcha domains are managed in iContact (`localhost` is not allowed). In the meantime, I've disabled CAPTCHA on the form to allow for testing locally.
- The form will confirm subscription in a new window. If better UX is required, we will need to revisit the estimate and this closed PR: https://github.com/nasa-jpl/explorer-1/pull/718

## Instructions to test

1. `make vue-storybook`
2. Go to [the story](http://localhost:6006/?path=/story/components-blocks-blocknewslettersignup--base-story) and try submitting the form. Note that it will always fail unless it's on dev, staging, or production.
3. You can also see the signup form in the context of a streamfield to check the width (second to last block on the page): http://localhost:6006/?path=/story/components-blocks-blockstreamfield--base-story

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [x] Safari
- [ ] Edge
