### PR TITLE
fixing visibility of description in mobile view of BlockCardGrid

### DIFF
--- a/.changeset/smart-ears-melt.md
+++ b/.changeset/smart-ears-melt.md
@@ -1,0 +1,5 @@
+---
+"@explorer-1/vue": patch
+---
+
+Fixing visibility of description in mobile view of BlockCardGrid.

--- a/packages/vue/src/components/BlockCardGrid/BlockCardGrid.vue
+++ b/packages/vue/src/components/BlockCardGrid/BlockCardGrid.vue
@@ -26,7 +26,7 @@
         :key="`item-mobile-${index}`"
         :label="card.label"
         :title="card.title"
-        :text="card.description"
+        :description="card.description"
         :image="card.image"
         :link="card.link"
         wrapper-class="swiper-slide mb-5"


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

It was discovered that the description field in `BlockCardGrid` was not visible on mobile. This was due to a misnamed prop. This PR fixes it.

## Instructions to test

1. `make vue-storybook`
2. View http://localhost:6006/iframe.html?globals=&args=&id=components-blocks-blockcardgrid--base-story#/
3. View using a mobile viewport. The description should still be visible when the grid becomes a carousel.

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
