### PR TITLE
Fix Storybook builds

### DIFF
--- a/packages/common/src/scss/_components.scss
+++ b/packages/common/src/scss/_components.scss
@@ -132,7 +132,7 @@
   @import 'components/NavSecondaryDropdownContent';
   @import 'components/NavSecondaryLink';
   @import 'components/NavSocial';
-  @import 'components/PodcastEpisodeCard.scss';
+  @import 'components/PodcastEpisodeCard';
   @import 'components/RoboticsDetailStats';
   @import 'components/RoboticsDetailStatsMini';
   @import 'components/SearchFilterGroupAccordionItem';

--- a/packages/common/src/scss/components/_BaseCarousel.scss
+++ b/packages/common/src/scss/components/_BaseCarousel.scss
@@ -1,4 +1,3 @@
-@import 'swiper/swiper-bundle.css';
 .BaseCarousel {
   .swiper {
     .swiper-prev {

--- a/packages/common/src/scss/components/_HomepageCarousel.scss
+++ b/packages/common/src/scss/components/_HomepageCarousel.scss
@@ -1,5 +1,3 @@
-@import 'swiper/swiper-bundle.css';
-
 .HomepageCarousel {
   .HomepageCarouselSlider {
     .swiper-pagination {

--- a/packages/common/src/scss/components/_HomepageMissionsCarousel.scss
+++ b/packages/common/src/scss/components/_HomepageMissionsCarousel.scss
@@ -1,5 +1,3 @@
-@import 'swiper/swiper-bundle.css';
-
 .HomepageMissionsCarousel {
   // container styles
   .swiper {

--- a/packages/common/src/scss/components/_MissionDetailHighlightsCarousel.scss
+++ b/packages/common/src/scss/components/_MissionDetailHighlightsCarousel.scss
@@ -1,5 +1,3 @@
-@import 'swiper/swiper-bundle.css';
-
 .MissionHighlightsCarousel {
   .swiper {
     .swiper-prev {

--- a/packages/common/src/scss/styles.scss
+++ b/packages/common/src/scss/styles.scss
@@ -22,11 +22,11 @@
 @import 'polyfills';
 @import 'animations';
 
-// templates
-@import 'templates';
-
 // components
 @import 'components';
+
+// templates
+@import 'templates';
 
 // print styles
 @import 'print';

--- a/packages/vue/src/components/BlockAnchor/BlockAnchor.vue
+++ b/packages/vue/src/components/BlockAnchor/BlockAnchor.vue
@@ -21,5 +21,5 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import '@explorer-1/common/src/scss/components/BlockAnchor.scss';
+@import '@explorer-1/common/src/scss/components/BlockAnchor';
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 4.0.31
       '@tailwindcss/forms':
         specifier: ^0.5.7
-        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4)))
+        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.5.4)))
       swiper:
         specifier: ^11.1.3
         version: 11.1.4
@@ -105,7 +105,7 @@ importers:
         version: 8.3.5(storybook@8.3.5)
       '@whitespace/storybook-addon-html':
         specifier: ^6.1.1
-        version: 6.1.1(prettier@3.3.1)(react-syntax-highlighter@15.5.0(react@18.3.1))
+        version: 6.1.1(prettier@3.6.2)(react-syntax-highlighter@15.5.0(react@18.3.1))
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.19(postcss@8.4.38)
@@ -129,7 +129,7 @@ importers:
         version: 8.3.5
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4))
+        version: 3.4.4(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.5.4))
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4)
@@ -159,7 +159,7 @@ importers:
         version: 4.0.31
       '@tailwindcss/forms':
         specifier: ^0.5.7
-        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4)))
+        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4)))
       click-outside-vue3:
         specifier: ^4.0.1
         version: 4.0.1
@@ -223,7 +223,7 @@ importers:
         version: 8.3.5(storybook@8.3.5)
       '@storybook/test-runner':
         specifier: ^0.19.0
-        version: 0.19.0(@types/node@20.14.2)(encoding@0.1.13)(prettier@3.3.1)(storybook@8.3.5)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4))
+        version: 0.19.0(@types/node@20.14.2)(encoding@0.1.13)(prettier@3.6.2)(storybook@8.3.5)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4))
       '@storybook/theming':
         specifier: ^8.3.5
         version: 8.3.5(storybook@8.3.5)
@@ -232,16 +232,16 @@ importers:
         version: 8.3.5(storybook@8.3.5)(vue@3.5.3(typescript@5.5.4))
       '@storybook/vue3-vite':
         specifier: ^8.3.5
-        version: 8.3.5(storybook@8.3.5)(vite@5.3.2(@types/node@20.14.2)(sass@1.77.4)(terser@5.31.1))(vue@3.5.3(typescript@5.5.4))
+        version: 8.3.5(storybook@8.3.5)(vite@5.3.2(@types/node@20.14.2)(sass@1.77.4)(terser@5.31.1))(vue@3.5.3(typescript@5.5.4))(webpack-sources@3.2.3)
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
         version: 5.0.5(vite@5.3.2(@types/node@20.14.2)(sass@1.77.4)(terser@5.31.1))(vue@3.5.3(typescript@5.5.4))
       '@vue/eslint-config-prettier':
         specifier: ^7.1.0
-        version: 7.1.0(eslint@9.4.0)(prettier@3.3.1)
+        version: 7.1.0(eslint@9.4.0)(prettier@3.6.2)
       '@whitespace/storybook-addon-html':
         specifier: ^6.1.1
-        version: 6.1.1(prettier@3.3.1)(react-syntax-highlighter@15.5.0(react@18.3.1))
+        version: 6.1.1(prettier@3.6.2)(react-syntax-highlighter@15.5.0(react@18.3.1))
       a11y-dialog:
         specifier: ^8.1.0
         version: 8.1.0
@@ -283,7 +283,7 @@ importers:
         version: 0.9.29(@storybook/blocks@8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5))(@storybook/components@8.3.5(storybook@8.3.5))(@storybook/core-events@8.1.11)(@storybook/preview-api@8.3.5(storybook@8.3.5))(@storybook/theming@8.3.5(storybook@8.3.5))(@storybook/types@8.1.11)(@storybook/vue3@8.3.5(storybook@8.3.5)(vue@3.5.3(typescript@5.5.4)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue@3.5.3(typescript@5.5.4))
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4))
+        version: 3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4))
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4)
@@ -292,7 +292,7 @@ importers:
         version: 5.5.4
       unplugin-vue-components:
         specifier: ^0.27.0
-        version: 0.27.0(@babel/parser@7.25.6)(@nuxt/kit@3.13.1(rollup@4.21.2))(rollup@4.21.2)(vue@3.5.3(typescript@5.5.4))
+        version: 0.27.0(@babel/parser@7.25.6)(@nuxt/kit@3.13.1(rollup@4.21.2)(webpack-sources@3.2.3))(rollup@4.21.2)(vue@3.5.3(typescript@5.5.4))
       vite:
         specifier: ^5.3.1
         version: 5.3.2(@types/node@20.14.2)(sass@1.77.4)(terser@5.31.1)
@@ -304,10 +304,10 @@ importers:
     dependencies:
       '@tailwindcss/forms':
         specifier: ^0.5.7
-        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4)))
+        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4)))
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4))
+        version: 3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4))
       tailwindcss-themer:
         specifier: ^4.0.0
         version: 4.0.0(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4)))
@@ -371,7 +371,7 @@ importers:
         version: 9.1.0(eslint@9.4.0)
       eslint-plugin-prettier:
         specifier: ^5.1.3
-        version: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@9.4.0))(eslint@9.4.0)(prettier@3.3.1)
+        version: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@9.4.0))(eslint@9.4.0)(prettier@3.6.2)
       eslint-plugin-storybook:
         specifier: ^0.8.0
         version: 0.8.0(eslint@9.4.0)(typescript@5.5.4)
@@ -393,13 +393,13 @@ importers:
         version: 4.0.31
       '@tailwindcss/forms':
         specifier: ^0.5.7
-        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4)))
+        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.5.4)))
       swiper:
         specifier: ^11.1.3
         version: 11.1.4
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4))
+        version: 3.4.4(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.5.4))
     devDependencies:
       '@explorer-1/common':
         specifier: workspace:*
@@ -445,7 +445,7 @@ importers:
         version: 0.5.1(magicast@0.3.4)(rollup@4.21.2)(typescript@5.5.4)(vue@3.5.3(typescript@5.5.4))(webpack-sources@3.2.3)
       '@tailwindcss/forms':
         specifier: ^0.5.7
-        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4)))
+        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4)))
       click-outside-vue3:
         specifier: ^4.0.1
         version: 4.0.1
@@ -509,7 +509,7 @@ importers:
         version: 4.0.31
       '@tailwindcss/forms':
         specifier: ^0.5.7
-        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4)))
+        version: 0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.5.4)))
       ag-grid-vue3:
         specifier: ^33.2.0
         version: 33.2.0(vue@3.5.3(typescript@5.5.4))
@@ -542,7 +542,7 @@ importers:
         version: 11.1.4
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4))
+        version: 3.4.4(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.5.4))
       twitter-widgets:
         specifier: ^2.0.0
         version: 2.0.0
@@ -828,6 +828,10 @@ packages:
 
   '@babel/runtime@7.24.7':
     resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.28.2':
+    resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/standalone@7.24.7':
@@ -2775,8 +2779,8 @@ packages:
   '@types/statuses@2.0.5':
     resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
 
-  '@types/unist@2.0.10':
-    resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.2':
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
@@ -6764,8 +6768,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.3.1:
-    resolution: {integrity: sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==}
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6785,8 +6789,8 @@ packages:
     resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
     engines: {node: '>=6'}
 
-  prismjs@1.29.0:
-    resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
   process-nextick-args@2.0.1:
@@ -8224,8 +8228,8 @@ packages:
   vue-component-type-helpers@2.0.21:
     resolution: {integrity: sha512-3NaicyZ7N4B6cft4bfb7dOnPbE9CjLcx+6wZWAg5zwszfO4qXRh+U52dN5r5ZZfc6iMaxKCEcoH9CmxxoFZHLg==}
 
-  vue-component-type-helpers@2.2.8:
-    resolution: {integrity: sha512-4bjIsC284coDO9om4HPA62M7wfsTvcmZyzdfR0aUlFXqq4tXxM1APyXpNVxPC8QazKw9OhmZNHBVDA6ODaZsrA==}
+  vue-component-type-helpers@3.0.5:
+    resolution: {integrity: sha512-uoNZaJ+a1/zppa/Vgmi8zIOP2PHXDN2rT8NyF+zQRK6ZG94lNB9prcV0GdLJbY9i9lrD47JOVIH92SaiA7oJ1A==}
 
   vue-demi@0.14.8:
     resolution: {integrity: sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==}
@@ -8763,6 +8767,8 @@ snapshots:
   '@babel/runtime@7.24.7':
     dependencies:
       regenerator-runtime: 0.14.1
+
+  '@babel/runtime@7.28.2': {}
 
   '@babel/standalone@7.24.7': {}
 
@@ -9795,6 +9801,35 @@ snapshots:
       - supports-color
       - webpack-sources
 
+  '@nuxt/kit@3.13.1(rollup@4.21.2)':
+    dependencies:
+      '@nuxt/schema': 3.13.1(rollup@4.21.2)(webpack-sources@3.2.3)
+      c12: 1.11.2(magicast@0.3.4)
+      consola: 3.2.3
+      defu: 6.1.4
+      destr: 2.0.3
+      globby: 14.0.2
+      hash-sum: 2.0.0
+      ignore: 5.3.2
+      jiti: 1.21.6
+      klona: 2.0.6
+      knitwork: 1.1.0
+      mlly: 1.7.1
+      pathe: 1.1.2
+      pkg-types: 1.2.0
+      scule: 1.3.0
+      semver: 7.6.3
+      ufo: 1.5.4
+      unctx: 2.3.1(webpack-sources@3.2.3)
+      unimport: 3.11.1(rollup@4.21.2)(webpack-sources@3.2.3)
+      untyped: 1.4.2
+    transitivePeerDependencies:
+      - magicast
+      - rollup
+      - supports-color
+      - webpack-sources
+    optional: true
+
   '@nuxt/module-builder@0.7.1(@nuxt/kit@3.13.1(magicast@0.3.4)(rollup@4.21.2)(webpack-sources@3.2.3))(nuxi@3.13.1)(sass@1.77.4)(typescript@5.5.4)(vue-tsc@2.1.6(typescript@5.5.4))(webpack-sources@3.2.3)':
     dependencies:
       '@nuxt/kit': 3.13.1(magicast@0.3.4)(rollup@4.21.2)(webpack-sources@3.2.3)
@@ -9970,7 +10005,7 @@ snapshots:
       postcss: 8.4.45
       postcss-nesting: 12.1.5(postcss@8.4.45)
       tailwind-config-viewer: 2.0.4(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4)))
-      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4))
+      tailwindcss: 3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4))
       ufo: 1.5.4
       unctx: 2.3.1(webpack-sources@3.2.3)
     transitivePeerDependencies:
@@ -10615,7 +10650,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.3.5(storybook@8.3.5)(typescript@5.5.4)(vite@5.3.2(@types/node@20.14.2)(sass@1.77.4)(terser@5.31.1))':
+  '@storybook/builder-vite@8.3.5(storybook@8.3.5)(typescript@5.5.4)(vite@5.3.2(@types/node@20.14.2)(sass@1.77.4)(terser@5.31.1))(webpack-sources@3.2.3)':
     dependencies:
       '@storybook/csf-plugin': 8.3.5(storybook@8.3.5)(webpack-sources@3.2.3)
       '@types/find-cache-dir': 3.2.1
@@ -10669,7 +10704,7 @@ snapshots:
     dependencies:
       storybook: 8.3.5
 
-  '@storybook/core-common@8.1.11(encoding@0.1.13)(prettier@3.3.1)':
+  '@storybook/core-common@8.1.11(encoding@0.1.13)(prettier@3.6.2)':
     dependencies:
       '@storybook/core-events': 8.1.11
       '@storybook/csf-tools': 8.1.11
@@ -10692,7 +10727,7 @@ snapshots:
       node-fetch: 2.7.0(encoding@0.1.13)
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier-fallback: prettier@3.3.1
+      prettier-fallback: prettier@3.6.2
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.6.2
@@ -10701,7 +10736,7 @@ snapshots:
       ts-dedent: 2.2.0
       util: 0.12.5
     optionalDependencies:
-      prettier: 3.3.1
+      prettier: 3.6.2
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -10811,14 +10846,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.3.5
 
-  '@storybook/test-runner@0.19.0(@types/node@20.14.2)(encoding@0.1.13)(prettier@3.3.1)(storybook@8.3.5)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4))':
+  '@storybook/test-runner@0.19.0(@types/node@20.14.2)(encoding@0.1.13)(prettier@3.6.2)(storybook@8.3.5)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4))':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/generator': 7.24.7
       '@babel/template': 7.24.7
       '@babel/types': 7.24.7
       '@jest/types': 29.6.3
-      '@storybook/core-common': 8.1.11(encoding@0.1.13)(prettier@3.3.1)
+      '@storybook/core-common': 8.1.11(encoding@0.1.13)(prettier@3.6.2)
       '@storybook/csf': 0.1.8
       '@storybook/csf-tools': 8.1.11
       '@storybook/preview-api': 8.3.5(storybook@8.3.5)
@@ -10857,9 +10892,9 @@ snapshots:
       '@types/express': 4.17.21
       file-system-cache: 2.3.0
 
-  '@storybook/vue3-vite@8.3.5(storybook@8.3.5)(vite@5.3.2(@types/node@20.14.2)(sass@1.77.4)(terser@5.31.1))(vue@3.5.3(typescript@5.5.4))':
+  '@storybook/vue3-vite@8.3.5(storybook@8.3.5)(vite@5.3.2(@types/node@20.14.2)(sass@1.77.4)(terser@5.31.1))(vue@3.5.3(typescript@5.5.4))(webpack-sources@3.2.3)':
     dependencies:
-      '@storybook/builder-vite': 8.3.5(storybook@8.3.5)(typescript@5.5.4)(vite@5.3.2(@types/node@20.14.2)(sass@1.77.4)(terser@5.31.1))
+      '@storybook/builder-vite': 8.3.5(storybook@8.3.5)(typescript@5.5.4)(vite@5.3.2(@types/node@20.14.2)(sass@1.77.4)(terser@5.31.1))(webpack-sources@3.2.3)
       '@storybook/vue3': 8.3.5(storybook@8.3.5)(vue@3.5.3(typescript@5.5.4))
       find-package-json: 1.2.0
       magic-string: 0.30.11
@@ -10887,7 +10922,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.3(typescript@5.5.4)
-      vue-component-type-helpers: 2.2.8
+      vue-component-type-helpers: 3.0.5
 
   '@stylistic/eslint-plugin-js@2.1.0(eslint@9.4.0)':
     dependencies:
@@ -10995,15 +11030,15 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@tailwindcss/forms@0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4)))':
+  '@tailwindcss/forms@0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4)))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4))
+      tailwindcss: 3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4))
 
-  '@tailwindcss/forms@0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4)))':
+  '@tailwindcss/forms@0.5.7(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.5.4)))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4))
+      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.5.4))
 
   '@trysound/sax@0.2.0': {}
 
@@ -11084,7 +11119,7 @@ snapshots:
 
   '@types/hast@2.3.10':
     dependencies:
-      '@types/unist': 2.0.10
+      '@types/unist': 2.0.11
 
   '@types/hast@3.0.4':
     dependencies:
@@ -11166,7 +11201,7 @@ snapshots:
 
   '@types/statuses@2.0.5': {}
 
-  '@types/unist@2.0.10': {}
+  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.2': {}
 
@@ -11526,12 +11561,12 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/eslint-config-prettier@7.1.0(eslint@9.4.0)(prettier@3.3.1)':
+  '@vue/eslint-config-prettier@7.1.0(eslint@9.4.0)(prettier@3.6.2)':
     dependencies:
       eslint: 9.4.0
       eslint-config-prettier: 8.10.0(eslint@9.4.0)
-      eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.10.0(eslint@9.4.0))(eslint@9.4.0)(prettier@3.3.1)
-      prettier: 3.3.1
+      eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.10.0(eslint@9.4.0))(eslint@9.4.0)(prettier@3.6.2)
+      prettier: 3.6.2
 
   '@vue/language-core@1.8.27(typescript@5.5.4)':
     dependencies:
@@ -11596,9 +11631,9 @@ snapshots:
 
   '@vue/shared@3.5.3': {}
 
-  '@whitespace/storybook-addon-html@6.1.1(prettier@3.3.1)(react-syntax-highlighter@15.5.0(react@18.3.1))':
+  '@whitespace/storybook-addon-html@6.1.1(prettier@3.6.2)(react-syntax-highlighter@15.5.0(react@18.3.1))':
     dependencies:
-      prettier: 3.3.1
+      prettier: 3.6.2
       react-syntax-highlighter: 15.5.0(react@18.3.1)
 
   '@yarnpkg/fslib@2.10.3':
@@ -12944,18 +12979,18 @@ snapshots:
     dependencies:
       eslint: 9.4.0
 
-  eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.10.0(eslint@9.4.0))(eslint@9.4.0)(prettier@3.3.1):
+  eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.10.0(eslint@9.4.0))(eslint@9.4.0)(prettier@3.6.2):
     dependencies:
       eslint: 9.4.0
-      prettier: 3.3.1
+      prettier: 3.6.2
       prettier-linter-helpers: 1.0.0
     optionalDependencies:
       eslint-config-prettier: 8.10.0(eslint@9.4.0)
 
-  eslint-plugin-prettier@5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@9.4.0))(eslint@9.4.0)(prettier@3.3.1):
+  eslint-plugin-prettier@5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@9.4.0))(eslint@9.4.0)(prettier@3.6.2):
     dependencies:
       eslint: 9.4.0
-      prettier: 3.3.1
+      prettier: 3.6.2
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.8
     optionalDependencies:
@@ -15938,21 +15973,21 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.38
 
-  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4)):
-    dependencies:
-      lilconfig: 3.1.2
-      yaml: 2.4.5
-    optionalDependencies:
-      postcss: 8.4.38
-      ts-node: 10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4)
-
-  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4)):
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.38
       ts-node: 10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4)
+
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.5.4)):
+    dependencies:
+      lilconfig: 3.1.2
+      yaml: 2.4.5
+    optionalDependencies:
+      postcss: 8.4.38
+      ts-node: 10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4)
 
   postcss-media-query-parser@0.2.3: {}
 
@@ -16127,7 +16162,7 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  prettier@3.3.1: {}
+  prettier@3.6.2: {}
 
   pretty-bytes@6.1.1: {}
 
@@ -16141,7 +16176,7 @@ snapshots:
 
   prismjs@1.27.0: {}
 
-  prismjs@1.29.0: {}
+  prismjs@1.30.0: {}
 
   process-nextick-args@2.0.1: {}
 
@@ -16309,10 +16344,10 @@ snapshots:
 
   react-syntax-highlighter@15.5.0(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.28.2
       highlight.js: 10.7.3
       lowlight: 1.20.0
-      prismjs: 1.29.0
+      prismjs: 1.30.0
       react: 18.3.1
       refractor: 3.6.0
 
@@ -17085,7 +17120,7 @@ snapshots:
       open: 7.4.2
       portfinder: 1.0.32
       replace-in-file: 6.3.5
-      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4))
+      tailwindcss: 3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4))
     transitivePeerDependencies:
       - supports-color
 
@@ -17095,9 +17130,9 @@ snapshots:
       just-unique: 4.2.0
       lodash.merge: 4.6.2
       lodash.mergewith: 4.6.2
-      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4))
+      tailwindcss: 3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4))
 
-  tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4)):
+  tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -17116,7 +17151,7 @@ snapshots:
       postcss: 8.4.38
       postcss-import: 15.1.0(postcss@8.4.38)
       postcss-js: 4.0.1(postcss@8.4.38)
-      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.5.4)(typescript@5.5.4))
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.2)(typescript@5.5.4))
       postcss-nested: 6.0.1(postcss@8.4.38)
       postcss-selector-parser: 6.1.0
       resolve: 1.22.8
@@ -17124,7 +17159,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4)):
+  tailwindcss@3.4.4(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.5.4)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -17143,7 +17178,7 @@ snapshots:
       postcss: 8.4.38
       postcss-import: 15.1.0(postcss@8.4.38)
       postcss-js: 4.0.1(postcss@8.4.38)
-      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.4))
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.5.4))
       postcss-nested: 6.0.1(postcss@8.4.38)
       postcss-selector-parser: 6.1.0
       resolve: 1.22.8
@@ -17528,7 +17563,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-vue-components@0.27.0(@babel/parser@7.25.6)(@nuxt/kit@3.13.1(rollup@4.21.2))(rollup@4.21.2)(vue@3.5.3(typescript@5.5.4)):
+  unplugin-vue-components@0.27.0(@babel/parser@7.25.6)(@nuxt/kit@3.13.1(rollup@4.21.2)(webpack-sources@3.2.3))(rollup@4.21.2)(vue@3.5.3(typescript@5.5.4)):
     dependencies:
       '@antfu/utils': 0.7.8
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
@@ -17544,6 +17579,26 @@ snapshots:
     optionalDependencies:
       '@babel/parser': 7.25.6
       '@nuxt/kit': 3.13.1(magicast@0.3.4)(rollup@4.21.2)(webpack-sources@3.2.3)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
+  unplugin-vue-components@0.27.0(@babel/parser@7.25.6)(@nuxt/kit@3.13.1(rollup@4.21.2))(rollup@4.21.2)(vue@3.5.3(typescript@5.5.4)):
+    dependencies:
+      '@antfu/utils': 0.7.8
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      chokidar: 3.6.0
+      debug: 4.3.5
+      fast-glob: 3.3.2
+      local-pkg: 0.5.0
+      magic-string: 0.30.10
+      minimatch: 9.0.4
+      resolve: 1.22.8
+      unplugin: 1.10.1
+      vue: 3.5.3(typescript@5.5.4)
+    optionalDependencies:
+      '@babel/parser': 7.25.6
+      '@nuxt/kit': 3.13.1(rollup@4.21.2)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -17908,7 +17963,7 @@ snapshots:
 
   vue-component-type-helpers@2.0.21: {}
 
-  vue-component-type-helpers@2.2.8: {}
+  vue-component-type-helpers@3.0.5: {}
 
   vue-demi@0.14.8(vue@3.5.3(typescript@5.5.4)):
     dependencies:


### PR DESCRIPTION
@sfimbres I noticed that Storybook builds were no longer working, which seemed off to me. After a bit of debugging, I made a revision to [your earlier PR](https://github.com/nasa-jpl/explorer-1/pull/732) (apologies for missing these the first time around!)

- including `@import 'swiper/swiper-bundle.css';` in the component scss itself is problematic, and that import is already included in _vendors.scss, so I removed it from a few files
- some minor cleanup just to make things more consistent