### PR TITLE
fix: BlockCardGridItem alignment

### DIFF
--- a/packages/vue/src/components/BlockCardGrid/BlockCardGrid.stories.js
+++ b/packages/vue/src/components/BlockCardGrid/BlockCardGrid.stories.js
@@ -13,15 +13,15 @@ export const BlockCardGridData = [
     title: 'Nimble Limbs',
     description:
       'The robot has four limbs, each with seven degrees of freedom. The robot has four limbs, each with seven degrees of freedom. The robot has four limbs, each with seven degrees of freedom.',
-    // image: {
-    //   alt: 'Fourth image',
-    //   src: {
-    //     height: 400,
-    //     url: 'https://picsum.photos/800/400',
-    //     width: 800
-    //   },
-    //   srcSet: 'https://picsum.photos/400/200 320w, https://picsum.photos/800/400 1024w'
-    // },
+    image: {
+      alt: 'Fourth image',
+      src: {
+        height: 400,
+        url: 'https://picsum.photos/800/400',
+        width: 800
+      },
+      srcSet: 'https://picsum.photos/400/200 320w, https://picsum.photos/800/400 1024w'
+    },
     link: {
       page: null,
       externalLink: ''


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Updates the `BlockCardGridItemElement` template to align contents to the top, even if there is no image.

## Instructions to test

1. `make vue-storybook`
2. View http://localhost:6006/?path=/story/components-blocks-blockcardgrid--base-story

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
