### PR TITLE
fix/workaround: iOS video thumbnails in BlockVideo/BaseVideo

### DIFF
--- a/packages/vue/src/components/BaseVideo/BaseVideo.vue
+++ b/packages/vue/src/components/BaseVideo/BaseVideo.vue
@@ -19,19 +19,19 @@
       >
         <template v-if="data.fileWebm">
           <source
-            :src="data.fileWebm"
+            :src="`${data.fileWebm}#t=0.1`"
             type="video/webm"
           />
         </template>
         <template v-if="data.file">
           <source
-            :src="data.file"
+            :src="`${data.file}#t=0.1`"
             type="video/mp4"
           />
         </template>
         <template v-if="data.fileOgg">
           <source
-            :src="data.fileOgg"
+            :src="`${data.fileOgg}#t=0.1`"
             type="video/ogg"
           />
         </template>
@@ -41,6 +41,10 @@
   </div>
 </template>
 <script lang="ts">
+/**
+ * Uses the Media Fragments URI (#t=0.1) to make sure iOS loads the first frame as a thumbnail
+ * TODO: remove #t=0.1 once we have implemented the video thumbnail/postcard
+ */
 import { defineComponent, type PropType } from 'vue'
 import type { VideoObject } from './../../interfaces'
 import BaseImagePlaceholder from './../BaseImagePlaceholder/BaseImagePlaceholder.vue'


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Native videos in `BlockVideo` don't load a thumbnail on iOS. This is a workaround that ensures the first frame will be loaded. 

### Important notes:
A couple notable reasons we may not want to merge this "fix":
- Note that iOS's behavior may be intentional for performance reasons.
- if the video is super short, like a few seconds, the video jogger will look slightly advanced: 
<img width="572" height="355" alt="image" src="https://github.com/user-attachments/assets/b76468b5-ef92-4141-8e15-88aa29ef5a55" />


## Instructions to test

1. Use an iphone or iphone simulator (XCode) to view `BlockVideo` http://localhost:6006/iframe.html?args=&globals=&id=components-blocks-blockvideo--base-story#/
2. There should be a thumbnail

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
