### PR TITLE
fixing font family in mobile internal nav

### DIFF
--- a/packages/html/src/components/AppBarInternal/AppBarInternal.js
+++ b/packages/html/src/components/AppBarInternal/AppBarInternal.js
@@ -88,7 +88,7 @@ export const AppBarInternalTemplate = ({
       </div>
     </div>
     <div class="lg:hidden block relative z-30 bg-white shadow-lg py-4">
-      <a class=" px-4 lg:px-0 lg:container mx-auto flex flex-row items-center leading-tight tracking-wide font-medium text-gray-dark" href="/" title="${siteTitle}">
+      <a class=" px-4 lg:px-0 lg:container mx-auto flex flex-row items-baseline leading-tighter font-display font-medium" href="/" title="${siteTitle}">
         <span class="text-3xl">
           ${orgNumber}
         </span>


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

The mobile version of the internal nav didn't get updated to use the new fonts. This PR remedies that.

## Instructions to test

1. `make html-storybook`
2. View http://localhost:7007/?path=/story/internal-header--default&globals=viewport.value:mobile2 and make sure Helvetica Display is being used for the org number and site name.

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
