### PR TITLE
Feature: Update metadataStacked component

### DIFF
--- a/packages/vue/src/components/MetadataStacked/MetadataStacked.vue
+++ b/packages/vue/src/components/MetadataStacked/MetadataStacked.vue
@@ -37,29 +37,25 @@ const props = defineProps({
 
 <template>
   <div class="MetadataStacked inline-flex flex-col flex-start gap-2.5 text-body-md">
-    <div class="flex flex-row gap-2.5 items-center self-stretch">
-      <svg
-        v-if="props.locationIcon === 'test'"
-        xmlns="http://www.w3.org/2000/svg"
-        width="28"
-        height="28"
-        viewBox="0 0 28 28"
-        fill="none"
-      >
-        <circle
-          cx="14"
-          cy="14"
-          r="14"
-          fill="#7C6500"
-        />
-      </svg>
+    <div
+      v-if="props.location"
+      class="flex flex-row gap-2.5 items-center self-stretch"
+    >
+      <img
+        v-if="props.locationIcon"
+        :src="props.locationIcon"
+        class="w-4 h-4"
+      />
       <IconLocation
         v-else
         class="MetadataStackedIcon text-jpl-red"
       />
       <span>{{ props.location }}</span>
     </div>
-    <div class="flex flex-row gap-2.5 items-center self-stretch">
+    <div
+      v-if="props.wait"
+      class="flex flex-row gap-2.5 items-center self-stretch"
+    >
       <IconHourglass class="MetadataStackedIcon text-jpl-red" />
       <span>{{ props.wait }}</span>
     </div>


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

<!-- Describe your pull request. -->

This PR extends the functionality of the `MetadataStacked` component:
- Hides the "location" text and icon if the `location` value is null
- Hides the "wait" text and icon if the `wait` value is is null
- Add functionality to pass a URL to `locationIcon` to replace default location icon

## Instructions to test

<!-- Provide instructions on how a reviewer can verify your work. -->
1. `make vue-storybook`
2. Navigate to [MetadataStacked story](http://localhost:6006/?path=/story/components-utilities-metadatastacked--base-story)
3. Verify the location metadata section now hides when `location` is null
4. Verify the wait time metadata section now hides when `wait` is null
5. Verify that we can pass a URL to update 1locationIcon`. ([Try this for example](https://www-stage.jpl.nasa.gov/temp-luis/open_house_app/map/images/icons/food_icon@2x.png))

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
