### PR TITLE
Modifying BlockCsrTable (legacy)

### DIFF
--- a/packages/vue/src/components/BlockCsrTable/BlockCsrTable.vue
+++ b/packages/vue/src/components/BlockCsrTable/BlockCsrTable.vue
@@ -2,8 +2,7 @@
 import { computed, reactive, ref, onMounted } from 'vue'
 import BaseLink from './../BaseLink/BaseLink.vue'
 import BaseModalDialog from '../BaseModal/BaseModalDialog.vue'
-import CsrAttachment from './CsrAttachment.vue'
-import CsrTestLimits from './CsrTestLimits.vue'
+import CsrDetails from './CsrDetails.vue'
 import CsrTestLimitsTable from './CsrTestLimitsTable.vue'
 import SearchInput from './../SearchInput/SearchInput.vue'
 
@@ -121,37 +120,11 @@ const colDefs = ref([
     }
   },
   {
-    field: 'Description',
-    headerName: 'Description',
-    wrapText: true,
-    autoHeight: true,
-    filterParams: {
-      buttons: ['reset', 'apply'],
-      closeOnApply: true
-    }
-  },
-  {
-    field: 'ExportPackageRates',
-    headerName: 'Test Limits',
-    cellDataType: 'object',
+    headerName: '',
     filter: false,
-    cellRenderer: CsrTestLimits,
+    cellRenderer: CsrDetails,
     cellRendererParams: {
       openModal: openModal.bind(this)
-    }
-  },
-  {
-    field: 'Attachment',
-    filter: true,
-    filterParams: {
-      filterOptions: ['blank', 'notBlank'],
-      defaultOption: 'notBlank',
-      buttons: ['reset', 'apply'],
-      closeOnApply: true
-    },
-    cellRenderer: CsrAttachment,
-    cellRendererParams: {
-      attachmentPrefix
     }
   }
 ])

--- a/packages/vue/src/components/BlockCsrTable/CsrDetails.vue
+++ b/packages/vue/src/components/BlockCsrTable/CsrDetails.vue
@@ -2,7 +2,7 @@
 import { reactive } from 'vue'
 import { type ExportPackageRate } from './BlockCsrTable.vue'
 
-interface CsrTestLimitsProps {
+interface CsrDetailsProps {
   params: {
     data: {
       ExportPackageRates: ExportPackageRate[]
@@ -10,7 +10,7 @@ interface CsrTestLimitsProps {
   }
 }
 
-const props = withDefaults(defineProps<CsrTestLimitsProps>(), {
+const props = withDefaults(defineProps<CsrDetailsProps>(), {
   params: undefined
 })
 const { params } = reactive(props)
@@ -21,13 +21,12 @@ const openModal = () => {
 }
 </script>
 <template>
-  <div class="CsrTestLimits">
+  <div class="CsrDetails">
     <p
-      v-if="params.data.ExportPackageRates?.length"
       class="text-action hover:text-action-hover hover:cursor-pointer underline"
       @click="openModal()"
     >
-      <span class="hidden lg:inline">View Test Limits</span>
+      <span class="hidden lg:inline">View Details</span>
       <span class="inline lg:hidden">View</span>
     </p>
   </div>


### PR DESCRIPTION
### Checklist

- [ ] Include a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [ ] List the environments / browsers in which you tested your changes.
- [ ] Tests, linting, or other required checks are passing.
- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Simplifies the table based on input from users.
- Removes "Attachment," "Description," and "Test Results" from the main view, and consolidates them into a "View details" modal. 
- The modal is the same as before (it already had all of the info needed)

## Instructions to test

1. `make vue-storybook`
2. View http://localhost:6006/?path=/story/components-featureflags-blockcsrtable--base-story 


## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [ ] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
