### PR TITLE
fix: focus outlines in NavInternal

### DIFF
--- a/.changeset/pretty-mugs-tap.md
+++ b/.changeset/pretty-mugs-tap.md
@@ -1,0 +1,5 @@
+---
+"@explorer-1/common": patch
+---
+
+Fixes outlines for NavInternal focus states

--- a/.changeset/pretty-mugs-tap.md
+++ b/.changeset/pretty-mugs-tap.md
@@ -1,5 +1,6 @@
 ---
+
 "@explorer-1/common": patch
----
+"@explorer-1/html": patch---
 
 Fixes outlines for NavInternal focus states

--- a/packages/common/src/scss/components/_NavInternal.scss
+++ b/packages/common/src/scss/components/_NavInternal.scss
@@ -88,7 +88,7 @@
         }
 
         &:focus {
-          @apply border-gray-dark/20 outline-none;
+          @apply -outline-offset-2;
         }
 
         &:hover {

--- a/packages/common/src/scss/components/_NavInternal.scss
+++ b/packages/common/src/scss/components/_NavInternal.scss
@@ -88,7 +88,7 @@
         }
 
         &:focus {
-          @apply -outline-offset-2;
+          @apply -outline-offset-4;
         }
 
         &:hover {

--- a/packages/html/src/components/NavInternal/NavInternal.js
+++ b/packages/html/src/components/NavInternal/NavInternal.js
@@ -95,7 +95,7 @@ export const NavInternalTemplate = ({ includeSearch, menuItems }) => {
         ${
           includeSearch
             ? `<div class="hidden lg:block border-t-3 border-transparent relative z-10">
-          <button id="NavSearchOpen" aria-label="Open search" class="flex flex-nowrap items-center py-6 px-1 border-b-3 can-hover:hover:text-gray-mid-dark focus:border-gray-dark/20 focus:outline-none border-transparent">
+          <button id="NavSearchOpen" aria-label="Open search" class="flex flex-nowrap items-center py-6 px-1 border-b-3 can-hover:hover:text-gray-mid-dark -outline-offset-4 border-transparent">
             <span class="font-text font-medium leading-tight tracking-[-.03rem] pr-2">
               Search
             </span>


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Addresses:
- https://github.jpl.nasa.gov/18x/WCP/issues/541

NavInternal focus states were customized, but not actually helpful. This PR removes the customization and returns the focus states to use to the default outline.

## Instructions to test

1. Ensure keyboard navigation is enabled for the browser you are using (I had to turn it on for Safari)
1. `make html-storybook`
2. view `NavInternal`: http://localhost:7007/iframe.html?id=internal-header--default&viewMode=story
3. Use your keyboard and `tab` to navigate through the nav. You should see clear blue outlines on the top level nav items.

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [x] Safari
- [ ] Edge
