### PR TITLE
NavInternal: close dropdown when clicking on a link

### DIFF
--- a/.changeset/soft-teams-run.md
+++ b/.changeset/soft-teams-run.md
@@ -1,0 +1,5 @@
+---
+"@explorer-1/common": patch
+---
+
+Updating JS for NavInternal to close the nav dropdown if the item clicked is a link.

--- a/packages/common/src/js/components/_HeaderInternal.js
+++ b/packages/common/src/js/components/_HeaderInternal.js
@@ -61,7 +61,8 @@ export default function () {
   const handleNavClickInsideDropdown = (e) => {
     if (navOpened) {
       const openItemPanel = document.getElementById('target_' + navOpened.id)
-      if (!openItemPanel.contains(e.target)) {
+      if (!openItemPanel.contains(e.target) || e.target.closest('a')) {
+        // if the opened nav item doesn't contain the clicked item, OR if the clicked item is a link, close the dropdown
         toggleNavDropdownVisibility(navOpened)
         navOpened = null
       }


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Supports https://github.jpl.nasa.gov/18x/WCP/issues/730

In NavInternal, when clicking on anchor links inside of a dropdown, the menu would remain open. This PR make sure the NavInternal dropdown will close when clicking on a link.

## Instructions to test

1. `pnpm install`
2. `make html-storybook`
3. View: http://localhost:7007/iframe.html?id=internal-header--default&viewMode=story#
4. Open a dropdown. Click on a link within the dropdown. The dropdown should close.

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [x] Safari
- [ ] Edge
