### PR TITLE
fixing typeface for accordion headings

### DIFF
--- a/.changeset/big-bikes-play.md
+++ b/.changeset/big-bikes-play.md
@@ -1,0 +1,5 @@
+---
+"@explorer-1/vue": patch
+---
+
+Fixing typeface for accordion headings

--- a/packages/vue/src/components/BaseAccordionItem/BaseAccordionItem.vue
+++ b/packages/vue/src/components/BaseAccordionItem/BaseAccordionItem.vue
@@ -106,7 +106,7 @@ defineSlots<{
             <button
               v-bind-once="{ id: headingId, 'aria-controls': panelId }"
               :aria-expanded="ariaExpanded"
-              class="BaseAccordion-trigger group flex flex-nowrap justify-between items-center w-full can-hover:hover:underline text-body-lg"
+              class="BaseAccordion-trigger group flex flex-nowrap justify-between items-center w-full can-hover:hover:underline text-body-lg font-primary"
               @click="handleClick()"
             >
               <slot name="heading">


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Fixes https://github.com/nasa-jpl/explorer-1/issues/876

## Instructions to test

1. `make vue-storybook`
2. View the BlockAccordion. http://localhost:6006/?path=/story/components-blocks-blockaccordion--base-story The heading typeface should be using helvetica text, not helvetica display

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [x] Safari
- [ ] Edge
