### PR TITLE
fixing display of detailUrl in BlockImage

### DIFF
--- a/.changeset/silly-adults-decide.md
+++ b/.changeset/silly-adults-decide.md
@@ -1,0 +1,5 @@
+---
+"@explorer-1/vue": patch
+---
+
+Fixing display of image detail URL in BlockImage.

--- a/packages/vue/src/components/BlockImage/BlockImageFullBleed.vue
+++ b/packages/vue/src/components/BlockImage/BlockImageFullBleed.vue
@@ -81,7 +81,7 @@ export default defineComponent({
           ...this.data,
           caption: this.theCaption,
           credit: this.theCredit,
-          detailUrl: this.customDetailUrl
+          detailUrl: this.customDetailUrl || this.data?.detailUrl
         }
       }
       return undefined

--- a/packages/vue/src/components/BlockImage/BlockImageStandard.vue
+++ b/packages/vue/src/components/BlockImage/BlockImageStandard.vue
@@ -71,7 +71,7 @@ export default defineComponent({
           ...this.data,
           caption: this.theCaption,
           credit: this.theCredit,
-          detailUrl: this.customDetailUrl
+          detailUrl: this.customDetailUrl || this.data?.detailUrl
         }
       }
       return undefined


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Supports:
- https://github.com/nasa-jpl/www-backend/issues/1437

In `BlockImage`, the `detailUrl` was getting overridden by the `customDetailUrl` in all cases. This PR fixes it.

## Instructions to test

1. `make vue-storybook`
2. View http://localhost:6006/?path=/story/components-blocks-blockimage--base-story and http://localhost:6006/?path=/story/components-blocks-blockimage--full-bleed. There should be a "Full Image Details" link at the end of the caption.

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [ ] Chrome
- [x] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
