### PR TITLE
Fix: Update BaseAudio.vue scrubber duration logic

### DIFF
--- a/packages/vue/src/components/BaseAudio/BaseAudio.vue
+++ b/packages/vue/src/components/BaseAudio/BaseAudio.vue
@@ -215,6 +215,8 @@ export default defineComponent({
       this.audio.removeEventListener('loadeddata', this._handleLoaded)
       this.audio.removeEventListener('pause', this._handlePlayPause)
       this.audio.removeEventListener('play', this._handlePlayPause)
+      this.audio.removeEventListener('durationchange', this._handleDurationChange)
+      this.audio.removeEventListener('loadedmetadata', this._handleDurationChange)
     }
   },
   methods: {
@@ -259,6 +261,9 @@ export default defineComponent({
       if (this.playing && !this.paused) {
         return
       } else if (this.audio) {
+        if (this.totalDuration === 0 && !isNaN(this.audio.duration)) {
+          this.totalDuration = this.audio.duration
+        }
         this.paused = false
         this.audio.play()
         this.playing = true
@@ -295,7 +300,7 @@ export default defineComponent({
         if (this.autoPlay) this.play()
 
         this.loaded = true
-        this.totalDuration = this.audio.duration
+        this.totalDuration = isNaN(this.audio.duration) ? 0 : this.audio.duration
       } else {
         throw new Error('Failed to load audio file')
       }
@@ -325,6 +330,11 @@ export default defineComponent({
     _handleEnded() {
       this.paused = this.playing = false
     },
+    _handleDurationChange() {
+      if (this.audio) {
+        this.totalDuration = isNaN(this.audio.duration) ? 0 : this.audio.duration
+      }
+    },
     init() {
       if (this.audio) {
         this.audio.addEventListener('timeupdate', this._handlePlayingUI)
@@ -332,6 +342,13 @@ export default defineComponent({
         this.audio.addEventListener('pause', this._handlePlayPause)
         this.audio.addEventListener('play', this._handlePlayPause)
         this.audio.addEventListener('ended', this._handleEnded)
+        this.audio.addEventListener('loadedmetadata', this._handleDurationChange)
+        this.audio.addEventListener('durationchange', this._handleDurationChange)
+
+        // Fallback: metadata already available before calling init() (e.g. cached audio)
+        if (this.totalDuration === 0 && !isNaN(this.audio.duration)) {
+          this.totalDuration = this.audio.duration
+        }
       }
       // TODO: VUE3: pass uuID to pauseOthers() method
       // eventBus.on('play', () => this.pauseOthers())


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [ ] Create/update the corresponding story if this includes a UI component.
- [ ] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [x] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

<!-- Describe your pull request. -->
Solves https://github.com/nasa-jpl/www/issues/370

This PR fixes the logic to update the `totalDuration` and `duration` values in `BaseAudio`.

Issues:
1. Metadata may not be fully available be available when `loadeddata` event is triggered, meaning `totalDuration` could be set to 0. There were previously no additional events to update the `totalDuration` value.
2. The `<audio>` element has preload="auto" and a bound :src, so the browser starts loading immediately when the element is rendered. Event listeners may not be triggered because they aren't attached until init() runs inside mounted()
3. On mobile, browsers typically ignore preload to conserve bandwidth. The audio metadata won't load until the user interacts, meaning `totalDuration` is generally set to 0. Since there are no additional checks to update this value, `totalDuration` may always remain 0 on mobile browsers.

Fixes:
1. Add event listeners for `loadedmetadata` and `durationchange` to handle any changes in duration. These events both call the new `_handleDurationChange()` function. 
Note: The addition of the event listener for `durationchange` may be useful for cases like livestreams, where the duration value can change often. In the future, we may want to explore additional logic to handle cases like infinity.
2. In `init()`, I added a fallback to update `totalDuration` in the event the audio button is fully rendered before the event listeners are attached.
3. I added fallback logic to check and update `totalDuration` when play() is called. This will properly update the `duration` on mobile.
 
## Instructions to test

<!-- Provide instructions on how a reviewer can verify your work. -->
**Test storybook**
1. Pull this Branch
2. run `make i`
3. run `make vue-storybook`
4. Verify http://localhost:6006/?path=/story/components-base-baseaudio--base-story
5. Verify http://localhost:6006/?path=/docs/components-blocks-blockaudio--docs

**Verify on Local**
1. [Set explorer-1 package to local path](https://github.com/nasa-jpl/www#setting-a-local-link)
2. Make backend
3. Make frontend
4. Create a podcast page and/or a Content Page with an audio block
5. Verify the scrubber is working. Test "play", "pause", "forward", "rewind", and manual scrubbing

## Tested in the following environments/browsers:

<!-- Delete this section if not applicable. -->

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [ ] Firefox ESR
- [ ] Firefox
- [ ] Safari
- [ ] Edge
