### PR TITLE
BlockInlineImage: prevent text overlap

### DIFF
--- a/.changeset/calm-images-wrap.md
+++ b/.changeset/calm-images-wrap.md
@@ -1,0 +1,5 @@
+---
+"@explorer-1/vue": patch
+---
+
+Prevent text overlap in BlockInlineImage layouts with wide images and long content.

--- a/packages/vue/src/components/BlockInlineImage/BlockInlineImage.stories.js
+++ b/packages/vue/src/components/BlockInlineImage/BlockInlineImage.stories.js
@@ -70,3 +70,25 @@ export const PortraitImage = {
     variant: 'large'
   }
 }
+
+export const WideImageLongLink = {
+  tags: ['regression-887'],
+  args: {
+    data: {
+      ...BlockInlineImageData.block,
+      text: `<h3>University of Nevada, Las Vegas (UNLV)</h3>
+        <p>Ordinary paragraph text should wrap within the text column without overlapping the adjacent image.</p>
+        <ul><li><a href="https://www.unlv.edu/sites/default/files/page_files/2693/Sciences-Research-QuantumComputing.pdf">https://www.unlv.edu/sites/default/files/page_files/2693/Sciences-Research-QuantumComputing.pdf</a></li></ul>`,
+      image: {
+        ...BaseImageCaptionData,
+        alt: 'Wide inline image',
+        src: {
+          height: 56,
+          url: '/explorer-1/images/png/brand-jpl-logo-222222-94h28w@2x.png',
+          width: 188
+        },
+        original: '/explorer-1/images/png/brand-jpl-logo-222222-94h28w@2x.png'
+      }
+    }
+  }
+}

--- a/packages/vue/src/components/BlockInlineImage/BlockInlineImage.vue
+++ b/packages/vue/src/components/BlockInlineImage/BlockInlineImage.vue
@@ -45,6 +45,7 @@
         :class="data.alignTo === 'right' ? 'col-start-3 lg:order-1' : 'col-start-6 lg:order-2'"
       >
         <BlockText
+          class="min-w-0"
           :variant="variant"
           :text="data.text"
         />


### PR DESCRIPTION
### Checklist

- [x] Include a description of your pull request and instructions for the reviewer to verify your work.
- [x] Link to the issue if this PR is issue-specific.
- [x] Create/update the corresponding story if this includes a UI component.
- [x] Create/update documentation. If not included, tell us why.
- [x] List the environments / browsers in which you tested your changes.
- [x] Tests, linting, or other required checks are passing.
- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../releases); good ones make that easier to scan.
  - PRs will be broadly categorized in the change log, but for even easier scanning, consider prefixing with a component name or other useful categorization, e.g., "BaseButton: fix layout bug", or "Storybook: Update dependencies".
- [ ] PR has been tagged with a [SemVer](https://semver.org/) label and a [general category label](https://github.com/nasa-jpl/explorer-1/blob/52994b671411f55961d7beb8851d4580ac3f434f/.github/release-drafter.config.yml#L21-L39), or skip-changelog.
  - These tags are used to do the aforementioned broad categorization in the change log and determine what the next release's version number should be.
  - [Release Drafter](https://github.com/marketplace/actions/release-drafter) will attempt to do the category labeling for you! Please double-check its work.

## Description

Fixes #887

Wide inline images can leave the text column narrower than the intrinsic width of long content. In Chromium, the direct `BlockText` flex item retains its `min-width: auto` behavior, which can keep it wider than the available column and cause it to overlap the adjacent image.

This change allows that flex item to shrink to its allocated width with `min-width: 0`.

A Storybook regression case covers the wide-image / long-content layout. The updated Storybook story is the component documentation for this case. A patch Changeset for `@explorer-1/vue` is included.

Local verification:

- Chromium and Firefox at 375, 768, 1024, 1440, and 1800 px
- normal and regression stories, plus the opposite alignment
- no collision, component escape, or page overflow
- target story accessibility checks pass in Chromium and Firefox
- Vue lint, Storybook lint, Vue build, Storybook build, and `git diff --check` pass
- the full Storybook run has 163 suites / 473 tests passing; its two failures are existing color-contrast failures in PodcastSeriesCarousel Base Story and ThumbnailCarousel Base Story

## Instructions to test

1. Start the Vue Storybook with `make vue-storybook`.
2. Open Components / Blocks / BlockInlineImage / Wide Image Long Link.
3. Resize across narrow and wide viewports and verify the heading, paragraph, and long link remain inside the text column without overlapping the adjacent image.
4. Open Align Right and Align Left to verify the normal and opposite layouts remain unchanged.

## Tested in the following environments/browsers:

### Operating System

- [x] macOS
- [ ] iOS
- [ ] iPadOS
- [ ] Windows

### Browser

- [x] Chrome
- [ ] Firefox ESR
- [x] Firefox
- [ ] Safari
- [ ] Edge
